### PR TITLE
fix: stdio logger stdout pollution + post-restore reconciliation hardening

### DIFF
--- a/.github/prompts/opsx-apply.prompt.md
+++ b/.github/prompts/opsx-apply.prompt.md
@@ -1,0 +1,149 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/prompts/opsx-archive.prompt.md
+++ b/.github/prompts/opsx-archive.prompt.md
@@ -1,0 +1,154 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/prompts/opsx-explore.prompt.md
+++ b/.github/prompts/opsx-explore.prompt.md
@@ -1,0 +1,170 @@
+---
+description: Enter explore mode - think through ideas, investigate problems, clarify requirements
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/prompts/opsx-propose.prompt.md
+++ b/.github/prompts/opsx-propose.prompt.md
@@ -1,0 +1,103 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.github/skills/openspec-apply-change/SKILL.md
+++ b/.github/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/skills/openspec-archive-change/SKILL.md
+++ b/.github/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/skills/openspec-explore/SKILL.md
+++ b/.github/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │         CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/skills/openspec-propose/SKILL.md
+++ b/.github/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+jobs:
+  test-and-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Persistent, vector-backed memory for MCP clients (Claude, Codex, OpenClaw, etc.).
 
-BHGBrain stores memories in SQLite (metadata + fulltext search) and Qdrant (semantic vectors), exposing them over the Model Context Protocol (MCP) via stdio or HTTP. It is designed to give AI agents a durable, searchable second brain that persists across sessions — with full lifecycle management, automatic deduplication, tiered retention, and hybrid search.
+BHGBrain stores memories in SQLite (metadata + fulltext search) and Qdrant (semantic vectors), exposing them over the Model Context Protocol (MCP) via stdio or HTTP. It is designed to give AI agents a durable, searchable second brain that persists across sessions - with full lifecycle management, automatic deduplication, tiered retention, and hybrid search.
 
 ---
 
@@ -26,11 +26,11 @@ BHGBrain stores memories in SQLite (metadata + fulltext search) and Qdrant (sema
    - [Memory Types](#memory-types)
    - [Namespaces and Collections](#namespaces-and-collections)
    - [Retention Tiers](#retention-tiers)
-   - [Tier Lifecycle — Assignment, Promotion, Sliding Window](#tier-lifecycle--assignment-promotion-sliding-window)
+   - [Tier Lifecycle - Assignment, Promotion, Sliding Window](#tier-lifecycle--assignment-promotion-sliding-window)
    - [Deduplication](#deduplication)
    - [Content Normalization](#content-normalization)
    - [Importance Scoring](#importance-scoring)
-   - [Categories — Persistent Policy Slots](#categories--persistent-policy-slots)
+   - [Categories - Persistent Policy Slots](#categories--persistent-policy-slots)
    - [Decay, Cleanup, and Archiving](#decay-cleanup-and-archiving)
    - [Pre-Expiry Warnings](#pre-expiry-warnings)
    - [Resource Limits and Capacity Budgets](#resource-limits-and-capacity-budgets)
@@ -38,7 +38,7 @@ BHGBrain stores memories in SQLite (metadata + fulltext search) and Qdrant (sema
     - [Semantic Search](#semantic-search)
     - [Fulltext Search](#fulltext-search)
     - [Hybrid Search](#hybrid-search)
-    - [Recall vs Search — Differences](#recall-vs-search--differences)
+    - [Recall vs Search - Differences](#recall-vs-search--differences)
     - [Filtering](#filtering)
     - [Score Thresholds and Tier Boosts](#score-thresholds-and-tier-boosts)
 12. [Backup & Restore](#backup--restore)
@@ -55,7 +55,7 @@ BHGBrain stores memories in SQLite (metadata + fulltext search) and Qdrant (sema
 
 ## Overview & Architecture
 
-BHGBrain is a persistent memory server built on the Model Context Protocol. It stores everything AI agents learn, decide, and observe across sessions — then makes that knowledge available via semantic recall, fulltext search, and injected context.
+BHGBrain is a persistent memory server built on the Model Context Protocol. It stores everything AI agents learn, decide, and observe across sessions - then makes that knowledge available via semantic recall, fulltext search, and injected context.
 
 ### Dual-Store Architecture
 
@@ -111,7 +111,7 @@ graph TD
 - **SQLite** (via `sql.js`, in-memory with periodic atomic flush to disk) is the **system of record** for all memory metadata, fulltext search index, categories, audit trail, revision history, and archive records.
 - **Qdrant** holds semantic vector embeddings for similarity search. Qdrant is always written after SQLite succeeds; failures are tracked via the `vector_synced` flag and surfaced in the health endpoint.
 - **OpenAI text-embedding-3-small** (default, configurable) generates 1536-dimensional embeddings for every memory.
-- **Atomic writes** ensure database files are never partially written — all disk I/O uses write-to-temp-then-rename.
+- **Atomic writes** ensure database files are never partially written - all disk I/O uses write-to-temp-then-rename.
 - **Deferred flush** batches access metadata updates (up to 5 seconds) to avoid per-request database flushes on read-heavy paths.
 
 ---
@@ -122,13 +122,13 @@ graph TD
 |---|---|---|
 | Node.js | ≥ 20.0.0 | LTS recommended |
 | Qdrant | ≥ 1.9 | Must be running before starting BHGBrain |
-| OpenAI API key | — | For embeddings (`text-embedding-3-small` by default). Server starts in degraded mode if missing. |
+| OpenAI API key | - | For embeddings (`text-embedding-3-small` by default). Server starts in degraded mode if missing. |
 
 ---
 
 ## Qdrant Setup
 
-BHGBrain **requires an external Qdrant instance**. Even in the default `embedded` mode, the server connects to `http://localhost:6333` — there is no bundled Qdrant binary. You must run it yourself.
+BHGBrain **requires an external Qdrant instance**. Even in the default `embedded` mode, the server connects to `http://localhost:6333` - there is no bundled Qdrant binary. You must run it yourself.
 
 ### Option A: Docker (recommended)
 
@@ -248,7 +248,7 @@ The file is created automatically on first run with all defaults applied. Edit i
     // "embedded" = connect to localhost:6333
     // "external" = connect to external_url (Qdrant Cloud, remote instance, etc.)
     "mode": "embedded",
-    // Only used for embedded mode (currently unused — Qdrant must be started externally)
+    // Only used for embedded mode (currently unused - Qdrant must be started externally)
     "embedded_path": "./qdrant",
     // External Qdrant URL (used when mode = "external")
     "external_url": null,
@@ -443,6 +443,8 @@ node dist/index.js --stdio
 # With a custom config file
 node dist/index.js --stdio --config=/path/to/config.json
 ```
+
+> **Log routing in stdio mode:** When `--stdio` is active, all structured logs (pino) are automatically redirected to **stderr**. This is required because stdout is exclusively reserved for the MCP JSON-RPC protocol. Mixing log output into stdout would corrupt the MCP handshake and cause clients to fail to load the server. To capture logs when running in stdio mode, redirect stderr: `node dist/index.js --stdio 2>bhgbrain.log`
 
 ### HTTP mode
 
@@ -715,7 +717,7 @@ Both point to the same Qdrant cluster. Each gets its own `device_id`. All memori
 
 ## Memory Management
 
-This section describes the complete memory lifecycle — from ingestion through classification, deduplication, access tracking, promotion, decay, and eventual expiration or permanent retention.
+This section describes the complete memory lifecycle - from ingestion through classification, deduplication, access tracking, promotion, decay, and eventual expiration or permanent retention.
 
 ### Memory Data Model
 
@@ -734,9 +736,9 @@ Every memory stored in BHGBrain is a `MemoryRecord` with the following fields:
 | `source` | `"cli" \| "api" \| "agent" \| "import"` | How the memory was created |
 | `checksum` | `string` | SHA-256 hash of normalized content (used for exact deduplication) |
 | `embedding` | `number[]` | Vector embedding (not stored in SQLite; lives in Qdrant) |
-| `importance` | `number (0–1)` | Importance score (default 0.5) |
+| `importance` | `number (0-1)` | Importance score (default 0.5) |
 | `retention_tier` | `"T0" \| "T1" \| "T2" \| "T3"` | Lifecycle tier governing TTL and cleanup behavior |
-| `expires_at` | `string (ISO 8601) \| null` | Expiry timestamp (null for T0 — never expires) |
+| `expires_at` | `string (ISO 8601) \| null` | Expiry timestamp (null for T0 - never expires) |
 | `decay_eligible` | `boolean` | Whether the memory participates in TTL cleanup (false for T0) |
 | `review_due` | `string (ISO 8601) \| null` | T1 review date (set to created_at + 365 days; reset on access) |
 | `access_count` | `number` | Number of times this memory has been retrieved |
@@ -804,7 +806,7 @@ If you do not provide a type, the pipeline defaults to `"semantic"`.
 
 **Namespaces** are top-level scoping identifiers that isolate memories from different contexts, users, or projects. All tool operations require a namespace (default: `"global"`).
 
-- Namespace pattern: `^[a-zA-Z0-9/-]{1,200}$` — alphanumeric characters, hyphens, and forward slashes
+- Namespace pattern: `^[a-zA-Z0-9/-]{1,200}$` - alphanumeric characters, hyphens, and forward slashes
 - Examples: `"global"`, `"project/alpha"`, `"user/kevin"`, `"tenant/acme-corp"`
 - Memories in different namespaces are never returned in each other's searches
 - Each namespace+collection pair maps to a separate Qdrant collection (named `bhgbrain_{namespace}_{collection}`)
@@ -813,7 +815,7 @@ If you do not provide a type, the pipeline defaults to `"semantic"`.
 
 - Collection pattern: `^[a-zA-Z0-9-]{1,100}$`
 - Examples: `"general"`, `"architecture"`, `"decisions"`, `"onboarding"`
-- Collections are tracked in the SQLite `collections` table with their embedding model and dimensions locked at creation time — you cannot mix embedding models within a collection
+- Collections are tracked in the SQLite `collections` table with their embedding model and dimensions locked at creation time - you cannot mix embedding models within a collection
 - Use the `collections` MCP tool to list, create, or delete collections
 
 **Isolation guarantees:**
@@ -825,7 +827,7 @@ If you do not provide a type, the pipeline defaults to `"semantic"`.
 
 ### Retention Tiers
 
-Every memory is assigned a **retention tier** at ingestion time that governs its entire lifecycle — how long it lives, how it's cleaned up, how strictly it's deduplicated, and whether it ever expires.
+Every memory is assigned a **retention tier** at ingestion time that governs its entire lifecycle - how long it lives, how it's cleaned up, how strictly it's deduplicated, and whether it ever expires.
 
 | Tier | Label | Default TTL | Decay Eligible | Examples |
 |---|---|---|---|---|
@@ -840,7 +842,7 @@ Every memory is assigned a **retention tier** at ingestion time that governs its
 
 - **T1**: `review_due` is set to `created_at + 365 days` and reset on each access. Memories approaching their `expires_at` are flagged with `expiring_soon: true` in search results.
 
-- **T2**: The default tier for most memories. 90-day sliding window — every access resets the TTL clock.
+- **T2**: The default tier for most memories. 90-day sliding window - every access resets the TTL clock.
 
 - **T3**: The most aggressive tier. Pattern-matched transient content (tickets, emails, standup notes) is automatically classified here. 30-day sliding window.
 
@@ -857,7 +859,7 @@ When a tier budget is exceeded, the health endpoint reports `degraded` and the c
 
 ---
 
-### Tier Lifecycle — Assignment, Promotion, Sliding Window
+### Tier Lifecycle - Assignment, Promotion, Sliding Window
 
 #### Tier Assignment
 
@@ -886,7 +888,7 @@ Tier assignment happens during the write pipeline, in this priority order:
 6. **T0 keyword signals (→ T0 for any source):**
    The same T0 keywords are checked for all sources (the T3 transient patterns are checked first). If a T0 keyword matches without a transient pattern, the memory is `T0`.
 
-7. **Default:** `T2` — the safe, forgiving default.
+7. **Default:** `T2` - the safe, forgiving default.
 
 ```mermaid
 flowchart TD
@@ -938,7 +940,7 @@ When a memory in tier `T2` or `T3` reaches the access threshold (`auto_promote_a
 
 Promotion cannot happen automatically to `T0`. Manual upgrade to `T0` is possible by passing `retention_tier: "T0"` on a subsequent `remember` call (which triggers the UPDATE path) or via the CLI's `bhgbrain tier set <id> T0`.
 
-Promotion is **monotonic** — automatic demotion never occurs. Tier demotion requires explicit user action.
+Promotion is **monotonic** - automatic demotion never occurs. Tier demotion requires explicit user action.
 
 When a memory is promoted, its `expires_at` is recomputed from the new tier's TTL using the current timestamp as the sliding window anchor.
 
@@ -1072,7 +1074,7 @@ If the embedding provider is unavailable and `pipeline.fallback_to_threshold_ded
 
 Before checksumming, embedding, or storing, all content goes through the normalization pipeline:
 
-1. **Control character stripping:** ASCII control characters (0x00–0x08, 0x0B, 0x0C, 0x0E–0x1F, 0x7F) are removed. Line feed (0x0A) and carriage return (0x0D) are preserved.
+1. **Control character stripping:** ASCII control characters (0x00-0x08, 0x0B, 0x0C, 0x0E-0x1F, 0x7F) are removed. Line feed (0x0A) and carriage return (0x0D) are preserved.
 
 2. **CRLF normalization:** `\r\n` → `\n`
 
@@ -1098,12 +1100,12 @@ Before checksumming, embedding, or storing, all content goes through the normali
 
 ### Importance Scoring
 
-Every memory has an `importance` field — a float from 0.0 to 1.0.
+Every memory has an `importance` field - a float from 0.0 to 1.0.
 
 **Default:** `0.5` if not provided by the caller.
 
 **How it's used:**
-- During deduplication UPDATE merges, importance is set to `max(existing, new)` — importance only increases through merges.
+- During deduplication UPDATE merges, importance is set to `max(existing, new)` - importance only increases through merges.
 - Stale memory candidates (flagged by the consolidation pass) must have `importance < 0.5` and no category to be eligible for the stale marking pass. This protects high-importance memories from being marked stale.
 - Future LLM-based extraction may assign importance based on content analysis.
 
@@ -1122,7 +1124,7 @@ Pass `importance` explicitly in the `remember` tool. Values range from `0.0` (ve
 
 ---
 
-### Categories — Persistent Policy Slots
+### Categories - Persistent Policy Slots
 
 Categories are a special storage mechanism for persistent, always-injected policy context. Unlike regular memories (which are retrieved via semantic search), category content is always included in the `memory://inject` resource payload.
 
@@ -1141,10 +1143,10 @@ Each category is assigned to one of four named slots:
 
 #### Category Behavior
 
-- Categories are **always T0** — they never expire, never decay, and cannot be cleaned up by the retention system.
+- Categories are **always T0** - they never expire, never decay, and cannot be cleaned up by the retention system.
 - Category content is stored as full text in SQLite (not embedded in Qdrant).
 - In the `memory://inject` payload, category content is prepended before any regular memories.
-- Categories support revisions — when you update a category with `category set`, the `revision` counter increments.
+- Categories support revisions - when you update a category with `category set`, the `revision` counter increments.
 - Category names must be unique. You can have multiple categories per slot (e.g., `"api-contracts"` and `"database-schema"` both in the `"architecture"` slot).
 - Category content can be up to 100,000 characters.
 
@@ -1240,7 +1242,7 @@ bhgbrain archive search <query>       # Search archived summaries by text
 bhgbrain archive restore <memory_id>  # Restore an archived memory
 ```
 
-**Restore semantics:** A restored memory is re-created as a **new** `T2` memory from the archived summary text. The original content (if longer than the summary) cannot be recovered — the archive stores only the 120-character summary. The restored memory receives fresh timestamps and a new UUID, and is re-embedded in Qdrant.
+**Restore semantics:** A restored memory is re-created as a **new** `T2` memory from the archived summary text. The original content (if longer than the summary) cannot be recovered - the archive stores only the 120-character summary. The restored memory receives fresh timestamps and a new UUID, and is re-embedded in Qdrant.
 
 ---
 
@@ -1292,13 +1294,13 @@ BHGBrain supports three search modes that can be used independently or combined.
 
 ### Semantic Search
 
-Semantic search uses OpenAI embeddings and Qdrant vector similarity (cosine distance) to find memories that are conceptually similar to the query — even if they use different words.
+Semantic search uses OpenAI embeddings and Qdrant vector similarity (cosine distance) to find memories that are conceptually similar to the query - even if they use different words.
 
 **How it works:**
 1. The query string is embedded using the same model as stored memories (`text-embedding-3-small`, 1536 dimensions).
 2. Qdrant is queried for the nearest neighbors in the target collection.
 3. Qdrant applies payload filters to exclude expired memories: only memories where `decay_eligible = false` (T0/T1) OR `expires_at > now()` are returned.
-4. Results are ranked by cosine similarity score (0.0–1.0, higher is more similar).
+4. Results are ranked by cosine similarity score (0.0-1.0, higher is more similar).
 5. Access metadata is updated for each returned memory (access_count++, last_accessed, sliding window expiry reset).
 
 **When to use:** Conceptual queries, questions about how something works, retrieving architectural decisions without knowing exact keywords.
@@ -1325,8 +1327,8 @@ Fulltext search uses SQLite's internal text matching to find memories containing
 1. The query is split into lowercase terms.
 2. Each term is matched against the `memories_fts` shadow table using `LIKE %term%` on `content`, `summary`, and `tags` columns.
 3. Results are ranked by the number of matching terms (more matches = higher rank).
-4. The rank is normalized to a 0.0–1.0 score: `min(1.0, term_count / 10)`.
-5. Archived memories are excluded (the FTS table is kept in sync with the main memories table — archived rows are removed from FTS).
+4. The rank is normalized to a 0.0-1.0 score: `min(1.0, term_count / 10)`.
+5. Archived memories are excluded (the FTS table is kept in sync with the main memories table - archived rows are removed from FTS).
 6. Access metadata is updated for returned results.
 
 **When to use:** Exact keyword searches, searching for specific identifiers (memory IDs, project names, system names), when you know the exact terminology used.
@@ -1387,7 +1389,7 @@ Hybrid search combines semantic and fulltext results using **Reciprocal Rank Fus
    RRF_score(item) = (semantic_weight / (K + semantic_rank))
                    + (fulltext_weight  / (K + fulltext_rank))
    ```
-   
+
    Where `K = 60` (standard RRF constant), `semantic_weight = 0.7`, `fulltext_weight = 0.3` (configurable via `search.hybrid_weights`).
 
 4. Items appearing in only one list receive `0` contribution from the other.
@@ -1397,7 +1399,7 @@ Hybrid search combines semantic and fulltext results using **Reciprocal Rank Fus
 
 **Graceful degradation:** If the embedding provider is unavailable, hybrid search silently falls back to fulltext-only results rather than erroring.
 
-**When to use:** Default for most queries — hybrid search provides the best recall because a memory might be returned by semantic matching even if the keywords don't match, or by fulltext even if the embedding is slightly off.
+**When to use:** Default for most queries - hybrid search provides the best recall because a memory might be returned by semantic matching even if the keywords don't match, or by fulltext even if the embedding is slightly off.
 
 ```json
 // Hybrid search (default mode)
@@ -1411,7 +1413,7 @@ Hybrid search combines semantic and fulltext results using **Reciprocal Rank Fus
 
 ---
 
-### Recall vs Search — Differences
+### Recall vs Search - Differences
 
 BHGBrain exposes two tools for memory retrieval with different semantics:
 
@@ -1419,20 +1421,20 @@ BHGBrain exposes two tools for memory retrieval with different semantics:
 |---|---|---|
 | **Primary purpose** | Retrieve memories most relevant to current context | Explore and investigate the memory store |
 | **Search mode** | Always semantic (vector similarity) | Configurable: `semantic`, `fulltext`, or `hybrid` (default) |
-| **Result limit** | 1–20 (default 5) | 1–50 (default 10) |
+| **Result limit** | 1-20 (default 5) | 1-50 (default 10) |
 | **Score filtering** | `min_score` filter applied (default 0.6) | No score filter |
 | **Type filtering** | Optional `type` filter (`episodic`/`semantic`/`procedural`) | No type filter |
 | **Tag filtering** | Optional `tags` filter (any matching tag) | No tag filter |
 | **Namespace** | Required (default `global`) | Required (default `global`) |
-| **Collection** | Optional — omit to search across all collections | Optional |
-| **Access tracking** | Yes — every recall updates access_count and sliding window | Yes — same behavior |
+| **Collection** | Optional - omit to search across all collections | Optional |
+| **Access tracking** | Yes - every recall updates access_count and sliding window | Yes - same behavior |
 | **Intended caller** | AI agents during task execution | Humans or admin agents doing investigation |
 
 **Score filtering in recall:**
-The `min_score` parameter (default 0.6) acts as a quality gate — only memories with cosine similarity ≥ 0.6 are returned. This prevents irrelevant results. You can lower `min_score` to retrieve more results at the cost of precision.
+The `min_score` parameter (default 0.6) acts as a quality gate - only memories with cosine similarity ≥ 0.6 are returned. This prevents irrelevant results. You can lower `min_score` to retrieve more results at the cost of precision.
 
 ```json
-// Recall example — semantic, filtered by type and tags
+// Recall example - semantic, filtered by type and tags
 {
   "query": "authentication architecture decisions",
   "namespace": "global",
@@ -1631,18 +1633,18 @@ Returns a `HealthSnapshot`:
 ```
 
 **Overall status logic:**
-- `unhealthy` — if SQLite or Qdrant is unhealthy
-- `degraded` — if embedding is degraded/unhealthy, OR retention is degraded (over capacity or unsynced vectors)
-- `healthy` — all components are healthy
+- `unhealthy` - if SQLite or Qdrant is unhealthy
+- `degraded` - if embedding is degraded/unhealthy, OR retention is degraded (over capacity or unsynced vectors)
+- `healthy` - all components are healthy
 
 **Component statuses:**
 
 | Component | Healthy condition | Degraded condition | Unhealthy condition |
 |---|---|---|---|
-| `sqlite` | `SELECT 1` succeeds | — | Query throws |
-| `qdrant` | `getCollections()` succeeds | — | Connection refused |
-| `embedding` | Embed API call succeeds | Missing credentials or unreachable | — |
-| `retention` | All budgets within limits, no unsynced vectors | Budget exceeded OR unsynced vectors > 0 | — |
+| `sqlite` | `SELECT 1` succeeds | - | Query throws |
+| `qdrant` | `getCollections()` succeeds | - | Connection refused |
+| `embedding` | Embed API call succeeds | Missing credentials or unreachable | - |
+| `retention` | All budgets within limits, no unsynced vectors | Budget exceeded OR unsynced vectors > 0 | - |
 
 **HTTP status codes:**
 - `200` for both `healthy` and `degraded`
@@ -1669,7 +1671,7 @@ Returns plain-text key-value metrics (Prometheus-compatible format):
 | `bhgbrain_rate_limit_buckets` | gauge | Active rate limit tracking buckets |
 | `bhgbrain_rate_limited_total` | counter | Total rate-limited requests |
 
-Histograms use a bounded circular buffer of the last 1,000 samples. Metrics are in-process only — there is no external push.
+Histograms use a bounded circular buffer of the last 1,000 samples. Metrics are in-process only - there is no external push.
 
 ---
 
@@ -1683,7 +1685,7 @@ When running in HTTP mode, requests to all endpoints except `/health` require a 
 Authorization: Bearer <your-token>
 ```
 
-The token value is read from the environment variable named in `transport.http.bearer_token_env` (default: `BHGBRAIN_TOKEN`). If the environment variable is not set, all HTTP requests are allowed through (a warning is logged but auth is not enforced — for loopback-only bindings this is acceptable).
+The token value is read from the environment variable named in `transport.http.bearer_token_env` (default: `BHGBRAIN_TOKEN`). If the environment variable is not set, all HTTP requests are allowed through (a warning is logged but auth is not enforced - for loopback-only bindings this is acceptable).
 
 **Fail-closed for external bindings:** If the HTTP host is non-loopback (not `127.0.0.1`, `localhost`, or `::1`) and no token is configured, the server **refuses to start**:
 
@@ -1762,12 +1764,12 @@ BHGBrain exposes MCP resources (readable via `ReadResource`) in addition to tool
 | `category://{name}` | Category | Full category content by name |
 | `collection://{name}` | Collection | Memories in a specific collection |
 
-### `memory://list` — Paginated Memory Listing
+### `memory://list` - Paginated Memory Listing
 
 Query parameters:
-- `namespace` — namespace to list (default: `global`)
-- `limit` — page size, 1–100 (default: 20)
-- `cursor` — opaque cursor from previous response for pagination
+- `namespace` - namespace to list (default: `global`)
+- `limit` - page size, 1-100 (default: 20)
+- `cursor` - opaque cursor from previous response for pagination
 
 Response:
 ```json
@@ -1781,7 +1783,7 @@ Response:
 
 Pagination uses composite cursors (`created_at|id`) for stable ordering. Ties at the same timestamp are broken by ID, ensuring no row is skipped or duplicated across pages.
 
-### `memory://inject` — Session Context Injection
+### `memory://inject` - Session Context Injection
 
 The inject resource builds a budgeted text payload for injecting into an LLM context window:
 
@@ -1790,7 +1792,7 @@ The inject resource builds a budgeted text payload for injecting into an LLM con
 3. The payload is truncated at `auto_inject.max_chars` (default 30,000 characters).
 
 Query parameters:
-- `namespace` — namespace to inject from (default: `global`)
+- `namespace` - namespace to inject from (default: `global`)
 
 Response:
 ```json
@@ -1837,7 +1839,7 @@ The interview walks through 10 sections:
 | 9. Tenant & environment map | Azure tenants, dev/staging/prod |
 | 10. Operating rules | Naming conventions, disambiguation, default assumptions |
 
-The output produces a clean structured profile with all 10 sections plus a disambiguation guide — exactly what BHGBrain needs to answer questions about your work reliably.
+The output produces a clean structured profile with all 10 sections plus a disambiguation guide - exactly what BHGBrain needs to answer questions about your work reliably.
 
 **Bootstrap memories default to T0.** Content ingested via the bootstrap flow should be tagged with `source: import` and `tags: ["bootstrap", "profile"]`. The heuristic classifier recognizes these signals and assigns T0 (foundational) tier.
 
@@ -1913,7 +1915,7 @@ BHGBrain exposes 9 MCP tools. All tools validate input with Zod schemas and retu
 
 ---
 
-### `remember` — Store a Memory
+### `remember` - Store a Memory
 
 Store content in BHGBrain with automatic deduplication, normalization, embedding, and tier classification.
 
@@ -1921,13 +1923,13 @@ Store content in BHGBrain with automatic deduplication, normalization, embedding
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `content` | `string` | **Yes** | — | The content to store. Max 100,000 characters. Control characters are stripped. Content matching secret patterns is rejected. |
+| `content` | `string` | **Yes** | - | The content to store. Max 100,000 characters. Control characters are stripped. Content matching secret patterns is rejected. |
 | `namespace` | `string` | No | `"global"` | Namespace scope. Pattern: `^[a-zA-Z0-9/-]{1,200}$` |
 | `collection` | `string` | No | `"general"` | Collection within the namespace. Max 100 chars. |
 | `type` | `"episodic" \| "semantic" \| "procedural"` | No | `"semantic"` | Memory type. Influences default tier assignment. |
 | `tags` | `string[]` | No | `[]` | Tags for filtering and classification. Max 20 tags, each max 100 chars. Pattern: `^[a-zA-Z0-9-]+$` |
-| `category` | `string` | No | — | Attach to a category slot (implies T0 tier). Max 100 chars. |
-| `importance` | `number (0–1)` | No | `0.5` | Importance score. Higher values are prioritized in stale cleanup. |
+| `category` | `string` | No | - | Attach to a category slot (implies T0 tier). Max 100 chars. |
+| `importance` | `number (0-1)` | No | `0.5` | Importance score. Higher values are prioritized in stale cleanup. |
 | `source` | `"cli" \| "api" \| "agent" \| "import"` | No | `"cli"` | Source of the memory. Affects default tier (e.g., agent+procedural → T1). |
 | `retention_tier` | `"T0" \| "T1" \| "T2" \| "T3"` | No | auto-assigned | Explicit tier override. Takes precedence over all heuristics. |
 
@@ -1944,9 +1946,9 @@ Store content in BHGBrain with automatic deduplication, normalization, embedding
 ```
 
 `operation` is one of:
-- `ADD` — new memory created
-- `UPDATE` — existing similar memory was updated (content merged)
-- `NOOP` — exact or near-exact duplicate; existing memory returned
+- `ADD` - new memory created
+- `UPDATE` - existing similar memory was updated (content merged)
+- `NOOP` - exact or near-exact duplicate; existing memory returned
 
 For `UPDATE` operations, `merged_with_id` contains the ID of the memory that was updated.
 
@@ -1982,7 +1984,7 @@ For `UPDATE` operations, `merged_with_id` contains the ID of the memory that was
 
 ---
 
-### `recall` — Semantic Recall
+### `recall` - Semantic Recall
 
 Retrieve the most relevant memories for a query using semantic (vector) similarity search with optional filtering.
 
@@ -1990,13 +1992,13 @@ Retrieve the most relevant memories for a query using semantic (vector) similari
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `query` | `string` | **Yes** | — | Recall query. Max 500 characters. |
+| `query` | `string` | **Yes** | - | Recall query. Max 500 characters. |
 | `namespace` | `string` | No | `"global"` | Namespace to search. |
-| `collection` | `string` | No | — | Filter to a specific collection. Omit to search the default collection. |
-| `type` | `"episodic" \| "semantic" \| "procedural"` | No | — | Filter results to a specific memory type. Applied post-retrieval. |
-| `tags` | `string[]` | No | — | Filter to memories with at least one matching tag. Applied post-retrieval. |
-| `limit` | `integer (1–20)` | No | `5` | Maximum number of results. |
-| `min_score` | `number (0–1)` | No | `0.6` | Minimum cosine similarity score. Results below this threshold are excluded. |
+| `collection` | `string` | No | - | Filter to a specific collection. Omit to search the default collection. |
+| `type` | `"episodic" \| "semantic" \| "procedural"` | No | - | Filter results to a specific memory type. Applied post-retrieval. |
+| `tags` | `string[]` | No | - | Filter to memories with at least one matching tag. Applied post-retrieval. |
+| `limit` | `integer (1-20)` | No | `5` | Maximum number of results. |
+| `min_score` | `number (0-1)` | No | `0.6` | Minimum cosine similarity score. Results below this threshold are excluded. |
 
 **Output:**
 
@@ -2023,7 +2025,7 @@ Retrieve the most relevant memories for a query using semantic (vector) similari
 
 ---
 
-### `forget` — Delete a Memory
+### `forget` - Delete a Memory
 
 Permanently delete a specific memory by its UUID. Removes from both SQLite and Qdrant. Creates an audit log entry.
 
@@ -2046,7 +2048,7 @@ Returns `NOT_FOUND` error if the ID does not exist or is already archived.
 
 ---
 
-### `search` — Multi-Mode Search
+### `search` - Multi-Mode Search
 
 Search memories using semantic, fulltext, or hybrid modes. Offers more control than `recall` and supports higher result limits.
 
@@ -2054,17 +2056,17 @@ Search memories using semantic, fulltext, or hybrid modes. Offers more control t
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `query` | `string` | **Yes** | — | Search query. Max 500 characters. |
+| `query` | `string` | **Yes** | - | Search query. Max 500 characters. |
 | `namespace` | `string` | No | `"global"` | Namespace to search. |
-| `collection` | `string` | No | — | Filter to a specific collection. |
+| `collection` | `string` | No | - | Filter to a specific collection. |
 | `mode` | `"semantic" \| "fulltext" \| "hybrid"` | No | `"hybrid"` | Search algorithm. |
-| `limit` | `integer (1–50)` | No | `10` | Maximum number of results. |
+| `limit` | `integer (1-50)` | No | `10` | Maximum number of results. |
 
-**Output:** Same structure as `recall` — `{ "results": [...] }` — but without the `min_score` gate and supporting up to 50 results.
+**Output:** Same structure as `recall` - `{ "results": [...] }` - but without the `min_score` gate and supporting up to 50 results.
 
 ---
 
-### `tag` — Manage Tags
+### `tag` - Manage Tags
 
 Add or remove tags from a memory. Tags are merged/filtered atomically; the memory content and embedding are not affected.
 
@@ -2072,7 +2074,7 @@ Add or remove tags from a memory. Tags are merged/filtered atomically; the memor
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `id` | `string (UUID)` | **Yes** | — | Memory to tag. |
+| `id` | `string (UUID)` | **Yes** | - | Memory to tag. |
 | `add` | `string[]` | No | `[]` | Tags to add. Max 20 tags total after merge. |
 | `remove` | `string[]` | No | `[]` | Tags to remove. |
 
@@ -2089,7 +2091,7 @@ Returns `INVALID_INPUT` if adding tags would exceed the 20-tag limit.
 
 ---
 
-### `collections` — Manage Collections
+### `collections` - Manage Collections
 
 List, create, or delete collections within a namespace.
 
@@ -2097,9 +2099,9 @@ List, create, or delete collections within a namespace.
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `action` | `"list" \| "create" \| "delete"` | **Yes** | — | Action to perform. |
+| `action` | `"list" \| "create" \| "delete"` | **Yes** | - | Action to perform. |
 | `namespace` | `string` | No | `"global"` | Namespace context. |
-| `name` | `string` | Required for `create`/`delete` | — | Collection name. Max 100 chars. |
+| `name` | `string` | Required for `create`/`delete` | - | Collection name. Max 100 chars. |
 | `force` | `boolean` | No | `false` | Required to delete a non-empty collection (deletes all memories). |
 
 **`list` output:**
@@ -2135,9 +2137,9 @@ List, create, or delete collections within a namespace.
 
 ---
 
-### `category` — Manage Policy Categories
+### `category` - Manage Policy Categories
 
-Manage persistent policy categories — always-available context blocks that are prepended to every `memory://inject` payload.
+Manage persistent policy categories - always-available context blocks that are prepended to every `memory://inject` payload.
 
 **Input:**
 
@@ -2183,7 +2185,7 @@ Manage persistent policy categories — always-available context blocks that are
 
 ---
 
-### `backup` — Backup and Restore
+### `backup` - Backup and Restore
 
 Create, list, or restore memory backups.
 
@@ -2291,9 +2293,9 @@ What happens on first start after upgrade:
 
 What happens on first start after upgrade:
 
-- SQLite schema is migrated in-place — new columns (`retention_tier`, `expires_at`, `decay_eligible`, `review_due`, `archived`, `vector_synced`) are added to the `memories` table with safe defaults.
+- SQLite schema is migrated in-place - new columns (`retention_tier`, `expires_at`, `decay_eligible`, `review_due`, `archived`, `vector_synced`) are added to the `memories` table with safe defaults.
 - All existing memories are assigned `retention_tier = T2` (standard retention, 90-day TTL by default).
-- Qdrant collections are unchanged — no re-indexing required.
+- Qdrant collections are unchanged - no re-indexing required.
 - Existing `config.json` files are fully forward-compatible. New config fields (`retention.tier_ttl`, `retention.tier_budgets`, etc.) are applied from defaults.
 
 **Backup recommended before upgrading** (precautionary):
@@ -2372,9 +2374,17 @@ When a T0 (foundational) memory is updated, the prior version is automatically s
 
 Collections lock their embedding model and dimensions at creation time. If you change `embedding.model` or `embedding.dimensions` in config, new memories in existing collections will be rejected with a `CONFLICT` error until you create a new collection. This prevents mixing incompatible embedding spaces in the same Qdrant index.
 
+### stdio Log Routing
+
+In stdio transport mode (`--stdio`), pino structured logs are written to **stderr** rather than stdout. This is non-negotiable for MCP protocol correctness: the MCP SDK uses stdout exclusively for JSON-RPC framing. Any non-JSON output on stdout (such as log lines) will cause MCP clients to fail the initialization handshake.
+
+- In HTTP mode, logs continue to write to stdout as normal.
+- The `createLogger()` function accepts an optional `destination` stream; `index.ts` passes `process.stderr` when `isStdio` is detected.
+- To capture stdio-mode logs to a file: `node dist/index.js --stdio 2>bhgbrain.log`
+
 ### Secret Detection
 
-The write pipeline rejects any content matching patterns for API keys, database credentials, private keys, and common secret formats. This is a safety net — never use BHGBrain as a secrets vault.
+The write pipeline rejects any content matching patterns for API keys, database credentials, private keys, and common secret formats. This is a safety net - never use BHGBrain as a secrets vault.
 
 ### Tier Promotion Does Not Reach T0
 

--- a/README.md
+++ b/README.md
@@ -1665,8 +1665,13 @@ Returns plain-text key-value metrics (Prometheus-compatible format):
 | Metric | Type | Description |
 |---|---|---|
 | `bhgbrain_tool_calls_total` | counter | Total tool invocations |
-| `bhgbrain_tool_duration_seconds_avg` | histogram | Average tool call duration |
-| `bhgbrain_tool_duration_seconds_count` | counter | Number of tool call duration samples |
+| `bhgbrain_tool_handler_ms_avg` | histogram | Average tool handler latency in milliseconds |
+| `bhgbrain_tool_handler_ms_p50` | histogram | 50th percentile tool handler latency |
+| `bhgbrain_tool_handler_ms_p95` | histogram | 95th percentile tool handler latency |
+| `bhgbrain_tool_handler_ms_p99` | histogram | 99th percentile tool handler latency |
+| `bhgbrain_tool_handler_ms_count` | counter | Number of tool handler latency samples |
+| `embedding_embed_batch_ms_p95` | histogram | 95th percentile embedding batch latency |
+| `search_total_ms_p95` | histogram | 95th percentile end-to-end search latency |
 | `bhgbrain_memory_count` | gauge | Current total memory count (updated on write/delete) |
 | `bhgbrain_rate_limit_buckets` | gauge | Active rate limit tracking buckets |
 | `bhgbrain_rate_limited_total` | counter | Total rate-limited requests |
@@ -2361,7 +2366,7 @@ The backup is stored in the data directory (`%LOCALAPPDATA%\BHGBrain\` on Window
 ### Operational Observability
 
 - **Bounded metrics:** Histogram values use a bounded circular buffer (last 1000 samples).
-- **Metric semantics:** Histogram metrics emit `_avg` and `_count` suffixes.
+- **Metric semantics:** Histogram metrics emit `_avg`, `_p50`, `_p95`, `_p99`, and `_count` suffixes.
 - **Atomic writes:** Database and backup file writes use write-to-temp-then-rename to prevent truncated partial files on crash.
 - **Deferred flush:** Read-path access metadata (touch counts) uses bounded async batching (5s window) instead of synchronous full-database flushes per request.
 - **Cross-store consistency:** SQLite updates are rolled back if the corresponding Qdrant operation fails.

--- a/codereview-gpt4.md
+++ b/codereview-gpt4.md
@@ -1,0 +1,137 @@
+# BHGBrain Code Review
+
+Scope: current working tree as reviewed on 2026-03-21.
+
+Baseline health:
+- `npm run lint` passed
+- `npm test` passed (`127` tests across `19` files)
+- `npm run build` passed
+
+## Overall assessment
+
+The codebase is in solid shape overall. It has a clear layered architecture, strict TypeScript settings, good schema validation, and better-than-average test coverage for a project of this size. I did not find evidence of broad quality regressions in the current tree.
+
+The main concerns are not style or organization problems; they are a handful of correctness gaps where the current behavior does not match the apparent API contract. The biggest issues are around collection scoping, backup/restore consistency, and one retention-path edge case.
+
+## Strengths
+
+- Clear separation between transport, tools, pipeline, storage, search, health, and backup layers.
+- Good use of Zod at API boundaries and structured error envelopes.
+- Strong baseline checks: typecheck, lint, tests, and build are all green.
+- The storage layer makes a real effort to preserve consistency across SQLite and Qdrant, including rollback behavior and vector sync tracking.
+- Tests cover most major subsystems instead of concentrating only on utilities.
+
+## Priority findings
+
+### 1. High: semantic and hybrid search silently collapse to the `general` collection when `collection` is omitted
+
+Why it matters:
+The public API treats `collection` as optional, which strongly suggests namespace-wide search when it is omitted. Fulltext search follows that model, but semantic and hybrid search do not.
+
+Evidence:
+- `SearchService` passes the optional `collection` through to Qdrant in both semantic and hybrid search paths: `src/search/index.ts:68-84`, `src/search/index.ts:118-123`
+- `QdrantStore.search()` replaces an omitted collection with `'general'`: `src/storage/qdrant.ts:126-160`
+- Fulltext search, by contrast, only applies a collection filter when one is provided: `src/storage/sqlite.ts:469-498`
+
+Impact:
+- `search` and `recall` can miss data stored in non-`general` collections.
+- Hybrid ranking becomes inconsistent because fulltext can see the full namespace while semantic search only sees one collection.
+
+Recommendation:
+- Either fan semantic search out across all namespace collections when `collection` is omitted, or redesign vector storage so a namespace can be searched as a whole.
+- Add regression tests for omitted-collection behavior in semantic, hybrid, and recall flows.
+
+### 2. High: exact deduplication is namespace-scoped, not collection-scoped
+
+Why it matters:
+Collections appear to be a first-class isolation boundary for memories, but exact dedup ignores that boundary. The same memory content cannot be stored twice in different collections within the same namespace, even though near-dedup logic is collection-aware.
+
+Evidence:
+- The write pipeline performs exact dedup with `getMemoryByChecksum(input.namespace, checksum)`: `src/pipeline/index.ts:107-116`
+- SQLite lookup only filters on `namespace` and `checksum`, not `collection`: `src/storage/sqlite.ts:413-422`
+- Near-dedup uses `searchSimilar()` with the requested collection: `src/pipeline/index.ts:131-136`
+
+Impact:
+- Users can get unexpected `NOOP` results when intentionally storing the same fact in multiple collections.
+- Exact dedup and semantic dedup follow different scoping rules, which is hard to reason about and likely surprising.
+
+Recommendation:
+- Decide whether collections are true write boundaries.
+- If they are, include `collection` in exact dedup lookup.
+- If they are not, document that clearly and make near-dedup follow the same scope.
+
+### 3. High: backup and restore only preserve SQLite state, not Qdrant vector state
+
+Why it matters:
+The application depends on SQLite and Qdrant together, but backups only serialize SQLite. After restore, metadata may say the system is healthy enough to use while Qdrant is stale, incomplete, or out of sync with the restored database.
+
+Evidence:
+- Backup creation serializes `this.storage.sqlite.exportData()` into the `.bhgb` artifact: `src/backup/index.ts:23-48`
+- Restore writes the SQLite database back and reloads SQLite only: `src/backup/index.ts:76-131`
+- `QdrantStore` has a `createSnapshot()` helper, but it is not used by backup flow: `src/storage/qdrant.ts:222-229`
+
+Impact:
+- Semantic search, similarity dedup, and vector-backed features can become inconsistent after restore.
+- Restoring to an older SQLite snapshot can reference memories whose vectors were deleted or overwrite metadata for vectors that still exist in Qdrant.
+
+Recommendation:
+- Treat backup/restore as a dual-store operation.
+- Either include Qdrant snapshots in the backup artifact or add a full vector reindex/rebuild step after restore.
+- If restore cannot restore Qdrant, explicitly mark restored memories as unsynced and surface that state clearly.
+
+### 4. Medium: disabling sliding-window expiry appears to clear `expires_at` on access
+
+Why it matters:
+`sliding_window_enabled = false` should stop extending TTLs, not remove expiry entirely. The current flow appears to convert "do not extend" into "set expiry to null."
+
+Evidence:
+- `MemoryLifecycleService.extendExpiry()` returns `null` when sliding-window extension is disabled: `src/domain/lifecycle.ts:122-125`
+- `SearchService.buildAccessUpdate()` turns that into `expires_at: null`: `src/search/index.ts:219-237`
+- `recordAccessBatch()` writes any provided `expires_at` value back to SQLite, including `null`: `src/storage/sqlite.ts:570-593`
+
+Impact:
+- Accessing a memory through search can make a time-bounded memory non-expiring when sliding windows are disabled.
+- This is a config-sensitive correctness bug that may go unnoticed in default settings.
+
+Recommendation:
+- Distinguish "no expiry change" from "explicitly clear expiry."
+- Returning `undefined` instead of `null` from the non-sliding path would be one straightforward fix.
+- Add tests for `sliding_window_enabled = false`.
+
+### 5. Medium: `collection://{name}` resource truncates before filtering
+
+Why it matters:
+The collection resource should show memories in that collection, but the implementation only grabs the first `50` memories in the namespace and filters that in memory.
+
+Evidence:
+- `ResourceHandler.handleCollection()` calls `listMemories(namespace, 50)` and then filters by `collection`: `src/resources/index.ts:225-238`
+
+Impact:
+- Collections can look incomplete if relevant memories are older than the newest `50` namespace entries.
+- The resource is effectively "newest 50 memories in the namespace that happen to be in this collection," not "this collection."
+
+Recommendation:
+- Add a storage query that lists memories by collection directly, ideally with pagination.
+- Add resource tests for collections with more than 50 namespace records and mixed collection membership.
+
+## Testing gaps worth addressing
+
+The test suite is healthy, but the highest-risk behaviors above are not well protected by regression tests.
+
+Examples:
+- Search tests cover passing an explicit collection, but not the omitted-collection semantic/hybrid behavior: `src/search/index.test.ts:72-104`
+- I did not find coverage for cross-collection exact dedup.
+- I did not find coverage for restore rehydrating vector state.
+- I did not find coverage for the `sliding_window_enabled = false` access path.
+- I did not find coverage for `collection://{name}` returning complete results.
+
+## Recommended next steps
+
+1. Fix collection scoping first. That is the most likely source of user-visible "missing data" bugs.
+2. Decide and document the intended collection semantics for deduplication.
+3. Make backup/restore explicitly dual-store safe or explicitly degraded with a required reindex step.
+4. Add regression tests for the omitted-collection, restore, and non-sliding expiry paths.
+
+## Final verdict
+
+This is a well-structured codebase with good engineering hygiene and a green baseline, but it still has a few important semantic mismatches at subsystem boundaries. I would be comfortable iterating on it, but I would fix the collection-search and backup/restore issues before calling the storage model fully production-safe.

--- a/codereview2.md
+++ b/codereview2.md
@@ -1,0 +1,124 @@
+# Code Review: Performance, Reliability, and Code Quality
+
+## Summary
+
+Comprehensive review of the BHGBrain codebase (commit 801e352) focusing on performance, reliability, and maintainability. The codebase shows excellent architectural patterns with dual transportation (HTTP/stdio), layered storage with SQLite + Qdrant, structured logging, and comprehensive error handling. The system demonstrates strong operational maturity with graceful degradation, circuit breaker patterns, and extensive configuration validation.
+
+## Architecture Strengths
+
+### 1. Excellent Dual Transport Support
+**Implementation:** Both HTTP (Express) and stdio (MCP) transports are well-implemented with proper security controls
+**Security:** Comprehensive auth middleware with bearer tokens, rate limiting, loopback enforcement, and fail-closed behavior for external bindings
+**Logging:** Proper log routing (stdout for HTTP, stderr for stdio to avoid MCP protocol pollution)
+
+### 2. Robust Storage Layer Design
+**SQLite Integration:** Comprehensive schema with proper indexing, FTS support, and audit logging
+**Qdrant Integration:** Vector store with proper health checks and error handling
+**Dual Storage Pattern:** Atomic operations with rollback capabilities when vector storage fails
+
+### 3. Strong Configuration System
+**Validation:** Extensive Zod schemas with conditional validation patterns
+**Security:** Environment variable validation with fail-closed behavior
+**Feature Flags:** Comprehensive toggles for retention, deduplication, and observability
+
+## Performance Analysis
+
+### Positive Findings
+1. **Efficient Search Implementation:** Hybrid search with RRF (Reciprocal Rank Fusion) and parallel execution
+2. **Access Count Batching:** Search results batch access updates rather than individual calls
+3. **Health Check Caching:** Embedding health checks cached for 30 seconds to avoid API spam
+4. **Memory Lifecycle Optimization:** Tiered retention with automatic promotion based on access patterns
+
+### Areas for Monitoring
+1. **Search Hydration:** Fallback to individual `getMemoryById()` calls if batch method unavailable (N+1 risk)
+2. **Retention Operations:** Large-scale cleanup operations could benefit from pagination for very large datasets
+3. **Vector Store Fallthrough:** Graceful degradation when embeddings unavailable maintains service availability
+
+## Reliability Assessment
+
+### Exceptional Error Handling
+1. **Structured Errors:** Consistent `BrainError` class with error codes and retryability indicators
+2. **Graceful Degradation:** Degraded embedding provider allows startup without API credentials
+3. **Atomic Operations:** SQLite + Qdrant updates with proper rollback on failure
+4. **Health Monitoring:** Comprehensive health checks with caching and component isolation
+
+### Resource Management
+1. **SQLite Connection:** Proper initialization and lifecycle management
+2. **Memory Cleanup:** Deferred flush operations with scheduling and cancellation
+3. **Configuration Reload:** Hot-reload capabilities for configuration changes
+
+### Security Implementation
+1. **Input Validation:** Request size limits, rate limiting with IP-based buckets
+2. **Authentication:** Bearer token validation with proper error responses
+3. **Network Security:** Loopback-only binding by default with explicit opt-out
+4. **Data Sanitization:** Log redaction for sensitive data (tokens, API keys)
+
+## Code Quality Assessment
+
+### Type Safety
+**Strengths:** Comprehensive TypeScript usage with proper interface definitions
+**Areas for Improvement:** 15 instances of `as any` casting, primarily for feature detection and parameter arrays
+- Most common pattern: Feature detection for optional methods (`typeof (obj as any).method === 'function'`)
+- SQL parameter arrays use `as any[]` for dynamic parameter binding
+
+### Test Coverage Analysis
+**Covered Modules (13 test files):**
+- Core storage: SQLite, storage manager, search
+- Domain logic: schemas, normalization, lifecycle
+- Services: health, backup, retention, pipeline
+- Transport: middleware
+- Tools and resources
+
+**Missing Test Coverage:**
+- `src/embedding/index.ts` - Critical OpenAI integration with health checks
+- `src/transport/http.ts` - HTTP server creation and route handling
+- `src/health/index.ts` - Health service (test exists but may need expansion)
+- `src/health/metrics.ts` - Metrics collection functionality
+- `src/health/logger.ts` - Structured logging setup
+- `src/cli/index.ts` - CLI entry point functionality
+
+### Error Handling Patterns
+**Consistent Approach:**
+- Domain-specific error functions (`invalidInput`, `notFound`, `conflict`, etc.)
+- Proper error propagation with context preservation
+- Retryability indicators for transient failures
+- MCP-compatible error envelope serialization
+
+## Security Review
+
+### Configuration Security
+- Environment variable validation with fail-closed behavior
+- External binding requires explicit authentication configuration
+- Loopback enforcement prevents accidental external exposure
+- Request size limits prevent DoS attacks
+
+### Data Protection
+- Log redaction for sensitive fields (tokens, API keys)
+- Bearer token validation with timing-attack safe comparison
+- Rate limiting with per-client isolation
+
+## Recommendations
+
+### Code Quality Improvements
+1. **Reduce Type Casting:** Implement proper interfaces for optional methods to eliminate `as any` usage
+2. **Expand Test Coverage:** Add comprehensive tests for embedding provider, HTTP transport, and CLI components
+3. **Documentation:** Add inline documentation for complex SQL queries and business logic
+
+### Performance Enhancements
+1. **Retention Optimization:** Consider pagination for very large retention operations (>10k memories)
+2. **Search Optimization:** Ensure batch methods are always available to prevent N+1 fallback
+3. **Caching Strategy:** Implement optional result caching for frequently accessed memories
+
+### Operational Readiness
+1. **Metrics Integration:** Expand metrics collection for p95/p99 latency tracking
+2. **Distributed Tracing:** Add trace context for operations spanning storage layers
+3. **Circuit Breakers:** Implement for external service calls (OpenAI, Qdrant) with configurable thresholds
+
+## Conclusion
+
+The BHGBrain codebase demonstrates exceptional engineering practices with comprehensive error handling, security controls, and operational features. The architecture is well-suited for production deployment with strong reliability guarantees. The code quality is high with minimal technical debt, and the system shows excellent resilience through graceful degradation patterns.
+
+**Deployment Readiness:** Production-ready with recommended monitoring and alerting
+**Maintenance Burden:** Low - Clean architecture with comprehensive configuration management
+**Scalability:** Good foundation with tiered storage and configurable retention policies
+**Security:** Strong security posture with comprehensive authentication and input validation

--- a/copilotgpt5.4codereview.md
+++ b/copilotgpt5.4codereview.md
@@ -1,0 +1,271 @@
+# Copilot GPT-5.4 Code Review
+
+## Scope
+
+This review covers:
+
+- The recent `restore-dual-store-backup-consistency` implementation
+- MCP server design across stdio and HTTP entry points
+- Memory architecture boundaries across SQLite, Qdrant, embeddings, pipeline, search, resources, backup, and health
+
+I only included findings that I re-checked directly in code.
+
+## Executive Summary
+
+The codebase has a strong foundation:
+
+- The stdio MCP path is implemented cleanly with the MCP SDK in `src/index.ts`.
+- The SQLite/Qdrant split is coherent and already has useful safety signals such as `vector_synced`, health checks, circuit breakers, and structured errors.
+- The new restore work is directionally correct because it separates metadata activation from vector readiness and adds regression coverage.
+
+The main gaps are not stylistic. They are consistency and operational issues:
+
+1. Restore can still fail after SQLite has already been activated if Qdrant clearing fails.
+2. Collection scope is not consistent across exact dedup, semantic search, and fulltext search.
+3. A few MCP-facing surfaces are incomplete or custom in ways that should be documented or tightened.
+4. Retention and shutdown behavior are still more manual than the configuration suggests.
+
+## What Looks Good
+
+### Strong MCP stdio implementation
+
+`src/index.ts` uses the MCP SDK request schemas directly for tools and resources, which is the right baseline for interoperability on stdio:
+
+- `ListToolsRequestSchema`
+- `CallToolRequestSchema`
+- `ListResourcesRequestSchema`
+- `ListResourceTemplatesRequestSchema`
+- `ReadResourceRequestSchema`
+
+That path is simple, easy to reason about, and aligned with MCP expectations.
+
+### Clear dual-store memory model
+
+The storage split is understandable:
+
+- SQLite owns metadata, lifecycle state, categories, audit history, and restore source-of-truth.
+- Qdrant owns vector indexing and semantic retrieval.
+
+That boundary is visible in `src/storage/index.ts`, `src/storage/sqlite.ts`, and `src/storage/qdrant.ts`, and it is reinforced by `vector_synced` and the health snapshot.
+
+### Restore contract is much better than before
+
+The new restore shape in `src/backup/index.ts` and `src/domain/types.ts` is a real improvement:
+
+- `metadata_activated`
+- `vector_reconciliation`
+- health-level `components.vector_reconciliation`
+
+That is a better operator contract than a single success flag.
+
+### Good test coverage around the new work
+
+The added tests in `src/backup/index.test.ts`, `src/health/index.test.ts`, and `src/storage/index.test.ts` cover the important happy-path and degraded-path cases and make the review easier to trust.
+
+## Verified Findings
+
+### 1. High: restore can fail after SQLite activation if Qdrant clearing fails
+
+**Files:** `src/backup/index.ts:105-145`, `src/storage/index.ts:169-177`
+
+Restore now does the right thing by reloading SQLite first, but it still treats `clearManagedVectors()` as part of the fatal path:
+
+- SQLite is written and reloaded at `src/backup/index.ts:105-120`
+- all active memories are marked unsynced at `src/backup/index.ts:123`
+- managed Qdrant collections are cleared at `src/backup/index.ts:124`
+
+If `clearManagedVectors()` throws, the method exits through the outer catch and returns a restore failure even though the runtime has already activated the restored SQLite state.
+
+That leaves the system in an awkward state:
+
+- restored metadata is active
+- vectors were intentionally invalidated
+- the API reports restore failure instead of degraded post-restore readiness
+
+For the contract introduced by this change, this is the biggest remaining stability issue.
+
+**Recommendation:** once SQLite activation succeeds, downgrade vector-clearing/reconciliation failures into an explicit degraded `vector_reconciliation` result instead of failing the whole restore.
+
+### 2. High: collection scope is inconsistent across the memory architecture
+
+**Files:** `src/storage/sqlite.ts:413-422`, `src/storage/sqlite.ts:472-500`, `src/storage/qdrant.ts:126-160`, `src/pipeline/index.ts:107-136`, `src/search/index.ts:71-123`
+
+Collection scoping means different things in different layers:
+
+- exact checksum dedup is namespace-scoped only in `getMemoryByChecksum(namespace, checksum)`
+- similarity dedup uses `(namespace, collection)` via `searchSimilar(...)`
+- Qdrant search defaults missing collection to `general` in `src/storage/qdrant.ts:137-138`
+- SQLite fulltext search searches all collections when collection is omitted in `src/storage/sqlite.ts:479-483`
+
+That means a caller omitting `collection` can get:
+
+- fulltext coverage across the whole namespace
+- semantic coverage from only `general`
+- checksum NOOP behavior that can suppress inserts across collections
+
+This is both a correctness issue and a memory-architecture completeness issue. Collections are not acting like a single, consistent boundary.
+
+**Recommendation:** make collection semantics explicit and consistent in exact dedup, semantic search, and hybrid search. If `collection` is omitted, every path should either search all collections or reject the request consistently.
+
+### 3. Medium: restore lock cleanup sits outside the protected `try/finally`
+
+**Files:** `src/backup/index.ts:76-87`, `src/storage/sqlite.ts:1013-1026`
+
+`BackupService.restore()` sets:
+
+- `this.restoreInProgress = true`
+- `this.storage.sqlite.beginLifecycleOperation('restore')`
+
+before entering the `try/finally`.
+
+If lifecycle acquisition throws at `beginLifecycleOperation(...)`, `restoreInProgress` is never cleared because the `finally` block has not been entered yet.
+
+The trigger window is narrow, but this is still a sticky-failure hazard: one pre-try failure can leave future restores permanently blocked until process restart.
+
+**Recommendation:** acquire the lifecycle lock inside a protected block, or only set `restoreInProgress` after the lifecycle operation is known to be active.
+
+### 4. Medium: partial reconciliation progress is not flushed if a batch fails mid-loop
+
+**Files:** `src/storage/index.ts:186-225`, `src/backup/index.ts:158-186`
+
+In `reconcileVectorsFromSqlite(...)`, each successful upsert marks one memory as synced, but the flush happens only after the entire batch:
+
+- per-memory `markVectorSync(...)` at `src/storage/index.ts:210-212`
+- batch flush at `src/storage/index.ts:216`
+
+If an upsert fails mid-batch, already rebuilt memories are marked synced only in the in-memory SQLite state. The restore path catches the error and reports pending reconciliation, but it does not persist the successful sub-batch before returning.
+
+This does not break the live process immediately, but it does make progress less durable:
+
+- a restart can lose those sync markers
+- the next reconciliation run can rebuild vectors that were already restored successfully
+
+**Recommendation:** flush successful progress per chunk, or catch per-item failures and continue with explicit accounting.
+
+### 5. Medium: `collection://{name}` is not a complete collection resource
+
+**Files:** `src/resources/index.ts:225-238`
+
+The collection resource currently does:
+
+- `listMemories(namespace, 50)`
+- then filters that in memory by collection
+
+So `collection://{name}` is not really a collection view. It is only a filtered slice of the newest 50 memories in a namespace, with no cursoring and no collection-native query.
+
+That is a completeness issue for MCP resource design because the resource name suggests a full collection representation.
+
+**Recommendation:** add a collection-scoped SQLite query plus cursor support, or rename/document this resource as a preview instead of a full collection listing.
+
+### 6. Medium: hybrid search silently hides Qdrant failures as fulltext fallback
+
+**Files:** `src/search/index.ts:118-126`
+
+`hybridSearch()` catches all errors around semantic retrieval:
+
+```ts
+try {
+  const vector = await this.embedding.embed(query);
+  const qdrantResults = await this.storage.qdrant.search(...);
+  semanticItems = qdrantResults.map(...);
+} catch {
+  // Embedding unavailable: fall back to fulltext only
+}
+```
+
+The comment says "Embedding unavailable", but the catch also covers Qdrant failures. So a vector-store outage is silently converted into a fulltext-only response.
+
+That is availability-friendly, but from a stability/operability perspective it hides an important system failure from callers and from result semantics.
+
+**Recommendation:** distinguish embedding failures from Qdrant failures. If fallback is intentional, record it explicitly in metrics/logs and consider surfacing a degraded flag in the response layer.
+
+### 7. Medium: HTTP transport is custom REST, not standard MCP-over-HTTP
+
+**Files:** `src/index.ts:135-143`, `src/transport/http.ts:15-68`
+
+The stdio path is MCP-native. The HTTP path is not. It exposes:
+
+- `POST /tool/:name`
+- `GET /resource`
+- `GET /health`
+- `GET /metrics`
+
+That may be completely fine for the product, but it is not the same thing as standard MCP Streamable HTTP / JSON-RPC transport. So from an MCP best-practice perspective, only stdio is broadly interoperable.
+
+**Recommendation:** document the HTTP surface as a custom operational API, or add a real MCP-over-HTTP transport if cross-client MCP interoperability over HTTP is a goal.
+
+### 8. Medium: retention lifecycle is configurable but not scheduled by the server runtime
+
+**Files:** `src/config/index.ts:58`, `src/index.ts`, `src/backup/retention.ts`, `src/cli/index.ts:234-371`
+
+The config exposes `cleanup_schedule`, and `RetentionService` exists, but the main server runtime never schedules it. The logic is reachable from the CLI, not from the long-running server process.
+
+That makes the architecture look more automated than it really is. Expiration and cleanup behavior depend on manual or external orchestration.
+
+**Recommendation:** either add an internal scheduler in the server process or clearly document that retention is operator-driven rather than automatic.
+
+### 9. Low/Medium: there is no graceful shutdown path to flush deferred work
+
+**Files:** `src/index.ts:34-150`, `src/storage/sqlite.ts:287-300`
+
+The server process has no signal handlers for `SIGINT` / `SIGTERM`, and SQLite uses deferred flushes in some read/update paths.
+
+That means shutdown behavior is abrupt:
+
+- no explicit SQLite flush
+- no coordinated HTTP stop
+- no explicit cleanup boundary
+
+For a memory system, graceful persistence on shutdown is part of the stability story.
+
+**Recommendation:** add signal handlers that stop listeners, flush SQLite, and then exit cleanly.
+
+## MCP Design Assessment
+
+### Good
+
+- MCP stdio handling is straightforward and SDK-native.
+- Tool/resource separation is clean.
+- Resource templates are exposed explicitly.
+- Error envelopes are converted into `isError` responses for stdio tool calls.
+
+### Needs tightening
+
+- HTTP is custom, not MCP-over-HTTP.
+- Some resources are previews rather than full representations.
+- Cross-collection behavior is not consistent enough for a multi-collection memory server.
+
+## Memory Architecture Assessment
+
+### Good
+
+- SQLite as metadata source-of-truth is coherent.
+- Qdrant as derived vector index is the right model.
+- `vector_synced` plus health reporting is a strong architectural seam.
+- The restore change improves operator-visible readiness semantics.
+
+### Main completeness gaps
+
+- Collection isolation is not consistently enforced across all storage/search paths.
+- Retention is modeled but not fully operationalized in the server lifecycle.
+- Reconciliation progress handling is good conceptually but still brittle in a few failure paths.
+
+## Suggested Next Steps
+
+1. Make post-activation restore failures degrade instead of failing the whole restore.
+2. Finish the collection-scope consistency work across checksum dedup, semantic search, and fulltext search.
+3. Make reconciliation progress durable on partial failure.
+4. Replace or clearly document the custom HTTP transport boundary.
+5. Add scheduled retention and graceful shutdown hooks.
+
+## Final Verdict
+
+This is a solid codebase with a good architectural direction, and the recent restore work is a meaningful improvement.
+
+The biggest remaining problem is not raw code quality. It is boundary consistency:
+
+- consistency between SQLite and Qdrant after failures
+- consistency of collection scope across subsystems
+- consistency between what the MCP-facing surfaces promise and what they fully return
+
+If those boundaries are tightened, the system will move from "good with caveats" to much more operationally reliable.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,22 @@
+import tseslint from 'typescript-eslint';
+
+export default [
+  {
+    ignores: ['coverage/**', 'dist/**', 'node_modules/**'],
+  },
+  {
+    files: ['src/**/*.ts', 'src/**/*.d.ts'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint.plugin,
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+    },
+  },
+];

--- a/openspec/changes/add-circuit-breakers/.openspec.yaml
+++ b/openspec/changes/add-circuit-breakers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/add-circuit-breakers/design.md
+++ b/openspec/changes/add-circuit-breakers/design.md
@@ -1,0 +1,68 @@
+## Context
+
+Standard circuit breaker pattern with three states:
+
+- **Closed:** Normal operation. Failures are counted. When `failureThreshold` consecutive failures are recorded within a window, the breaker transitions to Open.
+- **Open:** Fast-fail. All calls throw immediately without attempting the external service. After `openWindowMs`, transitions to Half-Open.
+- **Half-Open:** One probe call is allowed. If it succeeds, transitions back to Closed and resets the failure count. If it fails, resets the Open timer and stays Open.
+
+BHGBrain already has graceful degradation for embedding (`DegradedEmbeddingProvider`). The circuit breaker is a complementary, transient form of degradation: where `DegradedEmbeddingProvider` handles permanent credential absence, the circuit breaker handles temporary service unavailability. The distinction is important: a tripped breaker should recover automatically once the service is back; the degraded provider does not.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Protect OpenAI and Qdrant call sites from thundering-herd reconnection during outages.
+- Fast-fail during Open state to return errors quickly rather than blocking on timeout.
+- Auto-recover once the external service is restored (Half-Open probe).
+- Expose breaker state in `/health` for monitoring visibility.
+- Configurable thresholds via `resilience.circuit_breaker.*` config keys.
+
+**Non-Goals:**
+- Per-operation-type breakers (one breaker per external service is sufficient).
+- Distributed breaker state across multiple BHGBrain instances (in-process only; stateless restarts reset breakers).
+- Retry logic inside the circuit breaker (retries are a separate concern; use at the call site if needed).
+- Changing error types thrown to callers — callers already handle `embeddingUnavailable` and `internal` errors; the breaker should throw the same error types.
+
+## Decisions
+
+### Decision: One breaker per external service (not per method)
+
+**Why:** OpenAI failures typically affect all embedding operations simultaneously (rate limit, auth, network partition). Qdrant failures affect all vector operations. Per-method breakers would trip independently and create confusing partial-open states.
+
+**Alternative considered:** Per-method breakers. Rejected — increased configuration complexity without benefit.
+
+### Decision: Consecutive failure counting, not windowed rate
+
+**Why:** BHGBrain's operation volume is low to moderate. A windowed error rate (e.g., 50% failure rate in 60s) requires tracking timestamps. Consecutive failure count is simpler, sufficient, and predictable.
+
+**Alternative considered:** Windowed error rate. Deferred to a future iteration if needed.
+
+### Decision: Inject breakers as constructor parameters, not global singletons
+
+**Why:** Singleton breakers make testing hard (state leaks between tests). Constructor injection allows tests to provide fresh breakers and assert state transitions.
+
+### Decision: Surface breaker state in `/health` as a named component
+
+**Why:** An operator needs to know if `openai_embedding` or `qdrant` is circuit-open vs. genuinely unavailable. The health response already has a component map pattern (from `address-codereview-issues`); breaker state fits naturally as an additional component field.
+
+**Health response extension:**
+```json
+{
+  "status": "degraded",
+  "components": {
+    "sqlite": "healthy",
+    "qdrant": "unhealthy",
+    "embedding": "degraded"
+  },
+  "circuitBreakers": {
+    "openai_embedding": "open",
+    "qdrant": "closed"
+  }
+}
+```
+
+## Risks / Trade-offs
+
+- **[Risk] Breaker masks real failures during Half-Open probe** → Mitigation: probe failure resets the open window; the service remains protected and will retry the probe after another `openWindowMs`.
+- **[Risk] Too-tight threshold trips on transient single errors** → Mitigation: default `failureThreshold: 5` prevents single-error trips; configurable for environments with stricter SLOs.
+- **[Risk] Breaker state is lost on process restart** → Accepted. BHGBrain is a single-process server; in-process state is appropriate. Persisting breaker state would add complexity without proportional benefit.

--- a/openspec/changes/add-circuit-breakers/proposal.md
+++ b/openspec/changes/add-circuit-breakers/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+BHGBrain makes synchronous outbound calls to two external services: OpenAI (embedding) and Qdrant (vector search and storage). Neither has a circuit breaker. Under sustained failure — OpenAI rate limit event, Qdrant network partition, or a credential rotation — every incoming request that touches these services will fail immediately after its timeout, with no fast-fail or recovery window. This burns request budget, creates thundering-herd reconnection pressure, and prevents the system from recovering gracefully once the external service is restored.
+
+codereview2.md calls this out explicitly under Operational Readiness: "Implement circuit breakers for external service calls (OpenAI, Qdrant) with configurable thresholds."
+
+## What Changes
+
+- Introduce a `CircuitBreaker` class in `src/resilience/circuit-breaker.ts` with standard three-state semantics: **Closed** (normal), **Open** (fast-fail), **Half-Open** (probe).
+- Wrap `OpenAIEmbeddingProvider.embedBatch` with a circuit breaker instance.
+- Wrap `QdrantStorage.search`, `QdrantStorage.upsert`, and `QdrantStorage.delete` with a circuit breaker instance.
+- Expose circuit breaker state in the health check response (`/health`) so degradation from a tripped breaker is externally observable.
+- Add configuration keys under `resilience.circuit_breaker.*` to control failure threshold, open window duration, and half-open probe count.
+
+## Capabilities
+
+### New Capabilities
+- `circuit-breaker-resilience`: External service calls (OpenAI, Qdrant) are protected by configurable circuit breakers with Closed/Open/Half-Open state, fast-fail on open, and automatic recovery probing.
+- `circuit-breaker-health-visibility`: Circuit breaker state is included in the `/health` response, making tripped breakers observable to monitoring systems and operators.
+
+### Modified Capabilities
+- `degraded-embedding-and-health-semantics`: Embedding degradation now includes transient circuit-open state in addition to permanent missing-credentials degradation.
+
+## Impact
+
+- New file: `src/resilience/circuit-breaker.ts`
+- New file: `src/resilience/index.ts` (re-export)
+- `src/embedding/index.ts` — `OpenAIEmbeddingProvider` wraps `embedBatch` with breaker
+- `src/storage/qdrant.ts` — `QdrantStorage` wraps outbound methods with breaker
+- `src/health/index.ts` — Health check includes breaker state per service
+- `src/config/index.ts` — Add `resilience.circuit_breaker` config block with Zod schema
+- `src/index.ts` — Instantiate and inject circuit breakers at startup
+- Configuration: 3 new keys with sensible defaults (failure threshold: 5, open window: 30s, half-open probes: 1)

--- a/openspec/changes/add-circuit-breakers/tasks.md
+++ b/openspec/changes/add-circuit-breakers/tasks.md
@@ -1,59 +1,59 @@
 ## 1. Config Schema
 
-- [ ] 1.1 Add `resilience` block to `src/config/index.ts` Zod schema with `circuit_breaker` sub-object:
+- [x] 1.1 Add `resilience` block to `src/config/index.ts` Zod schema with `circuit_breaker` sub-object:
   - `failure_threshold: z.number().int().min(1).default(5)` — consecutive failures before Open
   - `open_window_ms: z.number().int().min(1000).default(30000)` — time in Open state before Half-Open probe
   - `half_open_probe_count: z.number().int().min(1).default(1)` — successful probes required to close
-- [ ] 1.2 Export `ResilienceConfig` type from config module
-- [ ] 1.3 Add `resilience` to `BrainConfig` and confirm existing config parsing tests still pass
+- [x] 1.2 Export `ResilienceConfig` type from config module
+- [x] 1.3 Add `resilience` to `BrainConfig` and confirm existing config parsing tests still pass
 
 ## 2. Implement `CircuitBreaker`
 
-- [ ] 2.1 Create `src/resilience/circuit-breaker.ts`
-- [ ] 2.2 Implement three states as a discriminated union or enum: `closed | open | half-open`
-- [ ] 2.3 Implement `execute<T>(fn: () => Promise<T>): Promise<T>` — throws `CircuitOpenError` immediately when Open; runs `fn`, tracks success/failure for state transitions
-- [ ] 2.4 Implement state transition logic:
+- [x] 2.1 Create `src/resilience/circuit-breaker.ts`
+- [x] 2.2 Implement three states as a discriminated union or enum: `closed | open | half-open`
+- [x] 2.3 Implement `execute<T>(fn: () => Promise<T>): Promise<T>` — throws `CircuitOpenError` immediately when Open; runs `fn`, tracks success/failure for state transitions
+- [x] 2.4 Implement state transition logic:
   - Closed → Open: on `failureThreshold` consecutive failures
   - Open → Half-Open: after `openWindowMs` elapsed since last Open transition
   - Half-Open → Closed: on `halfOpenProbeCount` successful executions; reset failure counter
   - Half-Open → Open: on any failure during probe; reset Open timer
-- [ ] 2.5 Expose `getState(): 'closed' | 'open' | 'half-open'` and `getStats(): { failures: number; lastOpenedAt: Date | null }` for health reporting
-- [ ] 2.6 Create `src/resilience/index.ts` re-exporting `CircuitBreaker` and `CircuitOpenError`
+- [x] 2.5 Expose `getState(): 'closed' | 'open' | 'half-open'` and `getStats(): { failures: number; lastOpenedAt: Date | null }` for health reporting
+- [x] 2.6 Create `src/resilience/index.ts` re-exporting `CircuitBreaker` and `CircuitOpenError`
 
 ## 3. Wrap OpenAI Embedding Provider
 
-- [ ] 3.1 Add `breaker?: CircuitBreaker` parameter to `OpenAIEmbeddingProvider` constructor
-- [ ] 3.2 In `embedBatch`, wrap the `fetch` call with `this.breaker?.execute(() => fetch(...)) ?? fetch(...)` — falls back to direct call when no breaker is injected (backward compatibility, and for tests that don't need a breaker)
-- [ ] 3.3 Confirm `healthCheck` does NOT go through the circuit breaker (health checks are intentional probes and should bypass fast-fail)
+- [x] 3.1 Add `breaker?: CircuitBreaker` parameter to `OpenAIEmbeddingProvider` constructor
+- [x] 3.2 In `embedBatch`, wrap the `fetch` call with `this.breaker?.execute(() => fetch(...)) ?? fetch(...)` — falls back to direct call when no breaker is injected (backward compatibility, and for tests that don't need a breaker)
+- [x] 3.3 Confirm `healthCheck` does NOT go through the circuit breaker (health checks are intentional probes and should bypass fast-fail)
 
 ## 4. Wrap Qdrant Storage
 
-- [ ] 4.1 Add `breaker?: CircuitBreaker` parameter to `QdrantStorage` constructor
-- [ ] 4.2 Wrap `search`, `upsert`, and `delete` method bodies with `this.breaker?.execute(...)` 
-- [ ] 4.3 Confirm that a tripped breaker throws an `internal` BrainError (not a raw `CircuitOpenError`) so callers receive a consistent error type
+- [x] 4.1 Add `breaker?: CircuitBreaker` parameter to `QdrantStorage` constructor
+- [x] 4.2 Wrap `search`, `upsert`, and `delete` method bodies with `this.breaker?.execute(...)` 
+- [x] 4.3 Confirm that a tripped breaker throws an `internal` BrainError (not a raw `CircuitOpenError`) so callers receive a consistent error type
 
 ## 5. Wire at Startup
 
-- [ ] 5.1 In `src/index.ts`, instantiate `CircuitBreaker` instances for `openai_embedding` and `qdrant` using config from `config.resilience.circuit_breaker`
-- [ ] 5.2 Pass the embedding breaker to `OpenAIEmbeddingProvider` constructor
-- [ ] 5.3 Pass the Qdrant breaker to `QdrantStorage` constructor
-- [ ] 5.4 Pass both breaker instances to `HealthService` for state reporting
+- [x] 5.1 In `src/index.ts`, instantiate `CircuitBreaker` instances for `openai_embedding` and `qdrant` using config from `config.resilience.circuit_breaker`
+- [x] 5.2 Pass the embedding breaker to `OpenAIEmbeddingProvider` constructor
+- [x] 5.3 Pass the Qdrant breaker to `QdrantStorage` constructor
+- [x] 5.4 Pass both breaker instances to `HealthService` for state reporting
 
 ## 6. Health Visibility
 
-- [ ] 6.1 Update `HealthService` to accept a `breakers: Record<string, CircuitBreaker>` map
-- [ ] 6.2 Add `circuitBreakers` field to the health check response: `{ [name]: 'closed' | 'open' | 'half-open' }`
-- [ ] 6.3 If any breaker is `open`, health status should be `degraded` (not `healthy`) even if the component itself would otherwise report healthy
+- [x] 6.1 Update `HealthService` to accept a `breakers: Record<string, CircuitBreaker>` map
+- [x] 6.2 Add `circuitBreakers` field to the health check response: `{ [name]: 'closed' | 'open' | 'half-open' }`
+- [x] 6.3 If any breaker is `open`, health status should be `degraded` (not `healthy`) even if the component itself would otherwise report healthy
 
 ## 7. Tests
 
-- [ ] 7.1 Unit test `CircuitBreaker`: assert Closed → Open transition at `failureThreshold`, fast-fail when Open, Open → Half-Open after `openWindowMs`, Half-Open → Closed on success, Half-Open → Open on failure
-- [ ] 7.2 Unit test `OpenAIEmbeddingProvider` with a breaker stub: assert breaker is invoked on embed calls; assert `healthCheck` bypasses the breaker
-- [ ] 7.3 Unit test `HealthService` with a tripped breaker: assert `circuitBreakers.openai_embedding` is `'open'` and overall status is `'degraded'`
+- [x] 7.1 Unit test `CircuitBreaker`: assert Closed → Open transition at `failureThreshold`, fast-fail when Open, Open → Half-Open after `openWindowMs`, Half-Open → Closed on success, Half-Open → Open on failure
+- [x] 7.2 Unit test `OpenAIEmbeddingProvider` with a breaker stub: assert breaker is invoked on embed calls; assert `healthCheck` bypasses the breaker
+- [x] 7.3 Unit test `HealthService` with a tripped breaker: assert `circuitBreakers.openai_embedding` is `'open'` and overall status is `'degraded'`
 
 ## 8. Commit
 
-- [ ] 8.1 Run `npm test` — confirm all tests pass
-- [ ] 8.2 Run `tsc --noEmit` — confirm zero type errors
+- [x] 8.1 Run `npm test` — confirm all tests pass
+- [x] 8.2 Run `tsc --noEmit` — confirm zero type errors
 - [ ] 8.3 Commit with message: `feat: add circuit breakers for OpenAI and Qdrant with health visibility (codereview2)`
 - [ ] 8.4 Push to active branch

--- a/openspec/changes/add-circuit-breakers/tasks.md
+++ b/openspec/changes/add-circuit-breakers/tasks.md
@@ -1,0 +1,59 @@
+## 1. Config Schema
+
+- [ ] 1.1 Add `resilience` block to `src/config/index.ts` Zod schema with `circuit_breaker` sub-object:
+  - `failure_threshold: z.number().int().min(1).default(5)` — consecutive failures before Open
+  - `open_window_ms: z.number().int().min(1000).default(30000)` — time in Open state before Half-Open probe
+  - `half_open_probe_count: z.number().int().min(1).default(1)` — successful probes required to close
+- [ ] 1.2 Export `ResilienceConfig` type from config module
+- [ ] 1.3 Add `resilience` to `BrainConfig` and confirm existing config parsing tests still pass
+
+## 2. Implement `CircuitBreaker`
+
+- [ ] 2.1 Create `src/resilience/circuit-breaker.ts`
+- [ ] 2.2 Implement three states as a discriminated union or enum: `closed | open | half-open`
+- [ ] 2.3 Implement `execute<T>(fn: () => Promise<T>): Promise<T>` — throws `CircuitOpenError` immediately when Open; runs `fn`, tracks success/failure for state transitions
+- [ ] 2.4 Implement state transition logic:
+  - Closed → Open: on `failureThreshold` consecutive failures
+  - Open → Half-Open: after `openWindowMs` elapsed since last Open transition
+  - Half-Open → Closed: on `halfOpenProbeCount` successful executions; reset failure counter
+  - Half-Open → Open: on any failure during probe; reset Open timer
+- [ ] 2.5 Expose `getState(): 'closed' | 'open' | 'half-open'` and `getStats(): { failures: number; lastOpenedAt: Date | null }` for health reporting
+- [ ] 2.6 Create `src/resilience/index.ts` re-exporting `CircuitBreaker` and `CircuitOpenError`
+
+## 3. Wrap OpenAI Embedding Provider
+
+- [ ] 3.1 Add `breaker?: CircuitBreaker` parameter to `OpenAIEmbeddingProvider` constructor
+- [ ] 3.2 In `embedBatch`, wrap the `fetch` call with `this.breaker?.execute(() => fetch(...)) ?? fetch(...)` — falls back to direct call when no breaker is injected (backward compatibility, and for tests that don't need a breaker)
+- [ ] 3.3 Confirm `healthCheck` does NOT go through the circuit breaker (health checks are intentional probes and should bypass fast-fail)
+
+## 4. Wrap Qdrant Storage
+
+- [ ] 4.1 Add `breaker?: CircuitBreaker` parameter to `QdrantStorage` constructor
+- [ ] 4.2 Wrap `search`, `upsert`, and `delete` method bodies with `this.breaker?.execute(...)` 
+- [ ] 4.3 Confirm that a tripped breaker throws an `internal` BrainError (not a raw `CircuitOpenError`) so callers receive a consistent error type
+
+## 5. Wire at Startup
+
+- [ ] 5.1 In `src/index.ts`, instantiate `CircuitBreaker` instances for `openai_embedding` and `qdrant` using config from `config.resilience.circuit_breaker`
+- [ ] 5.2 Pass the embedding breaker to `OpenAIEmbeddingProvider` constructor
+- [ ] 5.3 Pass the Qdrant breaker to `QdrantStorage` constructor
+- [ ] 5.4 Pass both breaker instances to `HealthService` for state reporting
+
+## 6. Health Visibility
+
+- [ ] 6.1 Update `HealthService` to accept a `breakers: Record<string, CircuitBreaker>` map
+- [ ] 6.2 Add `circuitBreakers` field to the health check response: `{ [name]: 'closed' | 'open' | 'half-open' }`
+- [ ] 6.3 If any breaker is `open`, health status should be `degraded` (not `healthy`) even if the component itself would otherwise report healthy
+
+## 7. Tests
+
+- [ ] 7.1 Unit test `CircuitBreaker`: assert Closed → Open transition at `failureThreshold`, fast-fail when Open, Open → Half-Open after `openWindowMs`, Half-Open → Closed on success, Half-Open → Open on failure
+- [ ] 7.2 Unit test `OpenAIEmbeddingProvider` with a breaker stub: assert breaker is invoked on embed calls; assert `healthCheck` bypasses the breaker
+- [ ] 7.3 Unit test `HealthService` with a tripped breaker: assert `circuitBreakers.openai_embedding` is `'open'` and overall status is `'degraded'`
+
+## 8. Commit
+
+- [ ] 8.1 Run `npm test` — confirm all tests pass
+- [ ] 8.2 Run `tsc --noEmit` — confirm zero type errors
+- [ ] 8.3 Commit with message: `feat: add circuit breakers for OpenAI and Qdrant with health visibility (codereview2)`
+- [ ] 8.4 Push to active branch

--- a/openspec/changes/add-circuit-breakers/tasks.md
+++ b/openspec/changes/add-circuit-breakers/tasks.md
@@ -55,5 +55,5 @@
 
 - [x] 8.1 Run `npm test` — confirm all tests pass
 - [x] 8.2 Run `tsc --noEmit` — confirm zero type errors
-- [ ] 8.3 Commit with message: `feat: add circuit breakers for OpenAI and Qdrant with health visibility (codereview2)`
-- [ ] 8.4 Push to active branch
+- [x] 8.3 Commit with message: `feat: add circuit breakers for OpenAI and Qdrant with health visibility (codereview2)`
+- [x] 8.4 Push to active branch

--- a/openspec/changes/add-percentile-metrics/.openspec.yaml
+++ b/openspec/changes/add-percentile-metrics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/add-percentile-metrics/design.md
+++ b/openspec/changes/add-percentile-metrics/design.md
@@ -1,0 +1,55 @@
+## Context
+
+`MetricsCollector` uses a `BoundedBuffer` (capacity 1000) as a circular buffer for histograms. The buffer stores raw values, making percentile computation straightforward: sort a copy of `buf.values()` and index into the result. There is no need for a streaming approximation (like t-digest or DDSketch) at this scale.
+
+Current output for a histogram named `search_latency_ms`:
+```
+search_latency_ms_avg 45.3
+search_latency_ms_count 87
+```
+
+Target output:
+```
+search_latency_ms_avg 45.3
+search_latency_ms_p50 38.1
+search_latency_ms_p95 112.4
+search_latency_ms_p99 201.7
+search_latency_ms_count 87
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+- Emit p50, p95, p99 for each histogram at zero additional memory cost (values are already stored in the buffer).
+- Document which operations are instrumented and what metric names they use.
+- Keep output format compatible with Prometheus-style scrapers (plain text, one metric per line).
+
+**Non-Goals:**
+- Streaming/approximate percentile algorithms (not needed at buffer capacity 1000).
+- Histograms with configurable bucket boundaries (future, if Prometheus native histogram format is needed).
+- Changing the buffer capacity (1000 samples is sufficient for the expected operation volume).
+
+## Decisions
+
+### Decision: Sort a copy, not in-place
+
+**Why:** `BoundedBuffer.values()` returns a new array already (spread copy). Sorting that array in `computePercentile` is safe and does not mutate the buffer. No additional defensive copy needed.
+
+### Decision: Emit p50, p95, p99 — not p75 or p99.9
+
+**Why:** p50 (median) gives the typical-case view, p95 is the standard SLO threshold, p99 catches the worst-case tail. Adding more percentiles is additive and can be done later. p99.9 requires a larger sample size to be meaningful.
+
+### Decision: Instrument at the call site, not in middleware
+
+**Why:** Latency attribution matters. A single `/tool/:name` request may span SQLite + Qdrant + embedding. Instrumenting each individually makes it possible to isolate which layer is slow. A single "request duration" metric obscures this.
+
+**Proposed instrumentation points:**
+- `src/embedding/index.ts` → `embedding_embed_ms`, `embedding_embed_batch_ms`
+- `src/search/index.ts` → `search_hydrate_ms`, `search_total_ms`
+- `src/storage/sqlite.ts` (or storage manager) → `sqlite_query_ms` for expensive queries
+- `src/tools/index.ts` → `tool_handler_ms` per tool name (label: tool name)
+
+## Risks / Trade-offs
+
+- **[Risk] Sort cost per `getMetrics` call for large buffers** → Mitigation: buffer capacity is 1000; sorting 1000 numbers is < 1ms. `getMetrics` is only called on `/metrics` requests, not on every operation.
+- **[Risk] New metric names break existing dashboards** → Mitigation: changes are additive. Existing `_avg` and `_count` names are preserved.

--- a/openspec/changes/add-percentile-metrics/proposal.md
+++ b/openspec/changes/add-percentile-metrics/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`MetricsCollector` in `src/health/metrics.ts` records histogram values in a bounded circular buffer but only computes and exposes `_avg` and `_count` per histogram. Average latency is a poor SLO signal: a fast average can mask a slow tail. Under real workloads — large memory payloads, Qdrant network variance, OpenAI embedding latency — p95 and p99 are the meaningful thresholds for detecting degradation before it becomes a user-visible outage.
+
+codereview2.md explicitly calls this out under Operational Readiness: "Expand metrics collection for p95/p99 latency tracking."
+
+## What Changes
+
+- Extend `MetricsCollector.getMetrics` to emit `_p50`, `_p95`, and `_p99` entries for each histogram in addition to the existing `_avg` and `_count`.
+- Add a `computePercentile(values: number[], p: number): number` utility (sorts a copy; no mutation of the buffer).
+- Update the `/metrics` HTTP endpoint output to include the new metric names in the existing plain-text format.
+- Expose `recordHistogram` call sites for latency-sensitive operations: embed calls, Qdrant search, SQLite queries, and tool handler round-trips.
+
+## Capabilities
+
+### New Capabilities
+- `histogram-percentile-metrics`: `MetricsCollector` computes and emits p50/p95/p99 percentiles for all recorded histograms.
+
+### Modified Capabilities
+- `search-resource-consistency-and-observability`: Observability now includes latency percentiles, not just averages.
+
+## Impact
+
+- `src/health/metrics.ts` — Add percentile computation; update `getMetrics` output.
+- `src/transport/http.ts` — `/metrics` output gains new lines; backward-compatible (additive only).
+- `src/tools/index.ts`, `src/search/index.ts`, `src/embedding/index.ts` — Add `recordHistogram` call sites for key latency points if not already instrumented.
+- No breaking changes. Consumers of `/metrics` receive additional lines.

--- a/openspec/changes/add-percentile-metrics/tasks.md
+++ b/openspec/changes/add-percentile-metrics/tasks.md
@@ -1,30 +1,30 @@
 ## 1. Add Percentile Computation to MetricsCollector
 
-- [ ] 1.1 Add `computePercentile(sortedValues: number[], p: number): number` as a module-level utility in `src/health/metrics.ts` — returns the value at the `p`th percentile (0–100) using nearest-rank method
-- [ ] 1.2 In `getMetrics`, for each histogram: sort a copy of `buf.values()`, then compute and emit p50, p95, p99 entries alongside the existing `_avg` and `_count`
-- [ ] 1.3 Emit percentile entries with names `${name}_p50`, `${name}_p95`, `${name}_p99` and type `'histogram'`
-- [ ] 1.4 Handle edge case: if `buf.values()` is empty, emit 0 for all percentiles (consistent with current avg behavior)
+- [x] 1.1 Add `computePercentile(sortedValues: number[], p: number): number` as a module-level utility in `src/health/metrics.ts` — returns the value at the `p`th percentile (0–100) using nearest-rank method
+- [x] 1.2 In `getMetrics`, for each histogram: sort a copy of `buf.values()`, then compute and emit p50, p95, p99 entries alongside the existing `_avg` and `_count`
+- [x] 1.3 Emit percentile entries with names `${name}_p50`, `${name}_p95`, `${name}_p99` and type `'histogram'`
+- [x] 1.4 Handle edge case: if `buf.values()` is empty, emit 0 for all percentiles (consistent with current avg behavior)
 
 ## 2. Instrument Key Latency Points
 
-- [ ] 2.1 In `src/embedding/index.ts`: wrap `embedBatch` fetch call with `Date.now()` delta and call `metrics.recordHistogram('embedding_embed_batch_ms', delta)` — requires passing `MetricsCollector` to the provider (via constructor or call-site injection)
-- [ ] 2.2 In `src/search/index.ts`: record `search_total_ms` from start of `search()` to return for each search mode
-- [ ] 2.3 In `src/tools/index.ts`: record `tool_handler_ms` with a label dimension or per-tool metric name (e.g., `tool_remember_ms`, `tool_recall_ms`) — choose the approach consistent with existing metric naming
-- [ ] 2.4 Confirm `MetricsCollector` is accessible from all instrumented call sites (already injected via `ToolContext`; verify embedding provider access path)
+- [x] 2.1 In `src/embedding/index.ts`: wrap `embedBatch` fetch call with `Date.now()` delta and call `metrics.recordHistogram('embedding_embed_batch_ms', delta)` — requires passing `MetricsCollector` to the provider (via constructor or call-site injection)
+- [x] 2.2 In `src/search/index.ts`: record `search_total_ms` from start of `search()` to return for each search mode
+- [x] 2.3 In `src/tools/index.ts`: record `tool_handler_ms` with a label dimension or per-tool metric name (e.g., `tool_remember_ms`, `tool_recall_ms`) — choose the approach consistent with existing metric naming
+- [x] 2.4 Confirm `MetricsCollector` is accessible from all instrumented call sites (already injected via `ToolContext`; verify embedding provider access path)
 
 ## 3. Update `/metrics` Endpoint Documentation
 
-- [ ] 3.1 Update inline comments in `src/transport/http.ts` metrics handler to note that histogram output now includes p50/p95/p99
-- [ ] 3.2 Update `README.md` observability section (if it documents metric names) to list the new percentile metric names
+- [x] 3.1 Update inline comments in `src/transport/http.ts` metrics handler to note that histogram output now includes p50/p95/p99
+- [x] 3.2 Update `README.md` observability section (if it documents metric names) to list the new percentile metric names
 
 ## 4. Tests
 
-- [ ] 4.1 In `src/health/metrics.test.ts` (from `expand-test-coverage`): add assertions that `getMetrics` emits `_p50`, `_p95`, `_p99` entries for a histogram with known values
-- [ ] 4.2 Assert `computePercentile` returns correct values for: empty array → 0, single value → that value, known distribution (e.g., [1..100] → p50=50, p95=95, p99=99)
-- [ ] 4.3 Assert histogram with capacity overflow (>1000 samples): percentile computation reflects only the most recent 1000 values
+- [x] 4.1 In `src/health/metrics.test.ts` (from `expand-test-coverage`): add assertions that `getMetrics` emits `_p50`, `_p95`, `_p99` entries for a histogram with known values
+- [x] 4.2 Assert `computePercentile` returns correct values for: empty array → 0, single value → that value, known distribution (e.g., [1..100] → p50=50, p95=95, p99=99)
+- [x] 4.3 Assert histogram with capacity overflow (>1000 samples): percentile computation reflects only the most recent 1000 values
 
 ## 5. Commit
 
-- [ ] 5.1 Run `npm test` and confirm all tests pass
-- [ ] 5.2 Commit with message: `feat: add p50/p95/p99 percentile metrics to MetricsCollector (codereview2)`
-- [ ] 5.3 Push to active branch
+- [x] 5.1 Run `npm test` and confirm all tests pass
+- [x] 5.2 Commit with message: `feat: add p50/p95/p99 percentile metrics to MetricsCollector (codereview2)`
+- [x] 5.3 Push to active branch

--- a/openspec/changes/add-percentile-metrics/tasks.md
+++ b/openspec/changes/add-percentile-metrics/tasks.md
@@ -1,0 +1,30 @@
+## 1. Add Percentile Computation to MetricsCollector
+
+- [ ] 1.1 Add `computePercentile(sortedValues: number[], p: number): number` as a module-level utility in `src/health/metrics.ts` — returns the value at the `p`th percentile (0–100) using nearest-rank method
+- [ ] 1.2 In `getMetrics`, for each histogram: sort a copy of `buf.values()`, then compute and emit p50, p95, p99 entries alongside the existing `_avg` and `_count`
+- [ ] 1.3 Emit percentile entries with names `${name}_p50`, `${name}_p95`, `${name}_p99` and type `'histogram'`
+- [ ] 1.4 Handle edge case: if `buf.values()` is empty, emit 0 for all percentiles (consistent with current avg behavior)
+
+## 2. Instrument Key Latency Points
+
+- [ ] 2.1 In `src/embedding/index.ts`: wrap `embedBatch` fetch call with `Date.now()` delta and call `metrics.recordHistogram('embedding_embed_batch_ms', delta)` — requires passing `MetricsCollector` to the provider (via constructor or call-site injection)
+- [ ] 2.2 In `src/search/index.ts`: record `search_total_ms` from start of `search()` to return for each search mode
+- [ ] 2.3 In `src/tools/index.ts`: record `tool_handler_ms` with a label dimension or per-tool metric name (e.g., `tool_remember_ms`, `tool_recall_ms`) — choose the approach consistent with existing metric naming
+- [ ] 2.4 Confirm `MetricsCollector` is accessible from all instrumented call sites (already injected via `ToolContext`; verify embedding provider access path)
+
+## 3. Update `/metrics` Endpoint Documentation
+
+- [ ] 3.1 Update inline comments in `src/transport/http.ts` metrics handler to note that histogram output now includes p50/p95/p99
+- [ ] 3.2 Update `README.md` observability section (if it documents metric names) to list the new percentile metric names
+
+## 4. Tests
+
+- [ ] 4.1 In `src/health/metrics.test.ts` (from `expand-test-coverage`): add assertions that `getMetrics` emits `_p50`, `_p95`, `_p99` entries for a histogram with known values
+- [ ] 4.2 Assert `computePercentile` returns correct values for: empty array → 0, single value → that value, known distribution (e.g., [1..100] → p50=50, p95=95, p99=99)
+- [ ] 4.3 Assert histogram with capacity overflow (>1000 samples): percentile computation reflects only the most recent 1000 values
+
+## 5. Commit
+
+- [ ] 5.1 Run `npm test` and confirm all tests pass
+- [ ] 5.2 Commit with message: `feat: add p50/p95/p99 percentile metrics to MetricsCollector (codereview2)`
+- [ ] 5.3 Push to active branch

--- a/openspec/changes/eliminate-any-type-casting/.openspec.yaml
+++ b/openspec/changes/eliminate-any-type-casting/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/eliminate-any-type-casting/design.md
+++ b/openspec/changes/eliminate-any-type-casting/design.md
@@ -1,0 +1,48 @@
+## Context
+
+`src/search/index.ts` uses three tiers of fallback to hydrate search results:
+1. `getMemoriesByIds` (batch, preferred) — checked via `typeof (this.storage.sqlite as any).getMemoriesByIds === 'function'`
+2. `getMemoryById` (per-row loop, N+1 fallback) — produces `(mem: any)` typed results
+3. `touchMemory` (minimal update fallback for `recordAccess`)
+
+This defensive structure was appropriate during iterative development when the storage interface was unstable. The batch methods (`getMemoriesByIds`, `recordAccessBatch`) are now implemented and stable, making the fallback tiers and their `as any` guards unnecessary. The `optimize-read-path-memory-efficiency` openspec requires `getMemoriesByIds` to always exist — this openspec enforces that at the type layer.
+
+Other cast sites include:
+- `as any[]` for SQLite parameter binding (widespread in `storage/sqlite.ts`)
+- Optional property access patterns in domain/tool code (e.g., `(obj as any).someOptionalProp`)
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `SqliteStorage` interface complete so all consumers compile without casts.
+- Eliminate `as any[]` in SQL parameter arrays via a named type alias.
+- Replace `as any` optional-property accesses with discriminated unions or type predicates.
+- Add ESLint enforcement to prevent new `as any` introductions.
+
+**Non-Goals:**
+- Migrating to a different ORM or query builder.
+- Rewriting the feature-detection pattern as a compatibility shim for old storage implementations.
+- Changing runtime behavior of any method.
+
+## Decisions
+
+### Decision: Extend interface rather than introduce adapter
+
+**Why:** The fallback tiers exist only because the methods weren't declared in the interface. Adding declarations is the minimal correct fix. An adapter layer would add indirection without benefit.
+
+**Alternative considered:** Runtime adapter that wraps old storage and provides missing methods. Rejected — there is no old storage to support; all methods already exist in the implementation.
+
+### Decision: `SqlParams` type alias over `unknown[]`
+
+**Why:** SQLite parameter binding accepts `string | number | null | Uint8Array` per the driver spec. A union type is more precise than `any[]` and prevents accidentally passing objects. `unknown[]` is safer than `any[]` but still too permissive.
+
+**Alternative considered:** Keep `any[]` for DX convenience. Rejected — `no-explicit-any` enforcement would block this anyway.
+
+### Decision: ESLint `error` (not `warn`) for `no-explicit-any`
+
+**Why:** Warnings are ignored in CI unless configured to fail. `error` ensures no new casts land without explicit `// eslint-disable` comments, which serve as documentation of intentional escapes.
+
+## Risks / Trade-offs
+
+- **[Risk] Hidden fallback paths mask absent methods in old storage versions** → Mitigation: fallback tiers are removed simultaneously with method declarations, so both must be present together. The `optimize-read-path-memory-efficiency` openspec already requires batch methods to exist.
+- **[Risk] ESLint error level breaks existing CI** → Mitigation: clean up all existing cast sites in the same PR before enabling the rule.

--- a/openspec/changes/eliminate-any-type-casting/proposal.md
+++ b/openspec/changes/eliminate-any-type-casting/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The codebase contains 15 instances of `as any` casting, identified in codereview2.md. The most structurally significant are in `src/search/index.ts`, where runtime feature detection (`typeof (this.storage.sqlite as any).getMemoriesByIds === 'function'`) is used to branch between batch and fallback hydration paths. This pattern bypasses TypeScript's type system entirely, suppresses IDE tooling, and makes it impossible to statically verify that required methods exist on the SQLite storage interface. SQL parameter arrays also use `as any[]` for dynamic binding. Additional `as any` casts exist in domain/tool code for optional property access patterns.
+
+The correct fix is not defensive casting — it is defining interfaces that reflect what the code actually requires.
+
+## What Changes
+
+- Extend the `SqliteStorage` interface (or its declared type) to include `getMemoriesByIds`, `recordAccessBatch`, `recordAccess`, and `touchMemory` as first-class typed members, eliminating the feature-detection guards in `search/index.ts`.
+- Introduce a typed SQL parameter helper (`SqlParams` or similar) to replace `as any[]` in query bindings.
+- Audit all remaining `as any` instances and replace each with a targeted interface, discriminated union, or type predicate.
+- After elimination, enforce `@typescript-eslint/no-explicit-any` at `error` level in ESLint config to prevent recurrence.
+
+## Capabilities
+
+### New Capabilities
+- `typed-storage-interface`: `SqliteStorage` declares all method signatures that search, retention, and pipeline code depend on, enabling compile-time verification.
+- `typed-sql-parameters`: SQL parameter arrays are typed via a dedicated helper type rather than cast.
+
+### Modified Capabilities
+- `search-read-hydration-efficiency`: Hydration path selection becomes a static interface dispatch, not a runtime typeof check.
+
+## Impact
+
+- `src/search/index.ts` — Remove all `as any` feature detection; dispatch directly against typed interface.
+- `src/storage/sqlite.ts` — Add missing method signatures to exported interface/class type.
+- `src/domain/*`, `src/tools/*`, `src/pipeline/*` — Targeted replacements for remaining cast instances.
+- `eslint.config.*` — Add `@typescript-eslint/no-explicit-any: error` rule.
+- No runtime behavior change; this is a type-layer cleanup with compile-time enforcement added.

--- a/openspec/changes/eliminate-any-type-casting/tasks.md
+++ b/openspec/changes/eliminate-any-type-casting/tasks.md
@@ -1,45 +1,45 @@
 ## 1. Audit All `as any` Instances
 
-- [ ] 1.1 Run `grep -rn "as any" src/` and produce a list of all cast sites with file + line
-- [ ] 1.2 Categorize each into: (a) feature detection, (b) SQL parameters, (c) optional property access, (d) other
-- [ ] 1.3 For each category, identify the minimal interface change that eliminates the cast
+- [x] 1.1 Run `grep -rn "as any" src/` and produce a list of all cast sites with file + line
+- [x] 1.2 Categorize each into: (a) feature detection, (b) SQL parameters, (c) optional property access, (d) other
+- [x] 1.3 For each category, identify the minimal interface change that eliminates the cast
 
 ## 2. Extend `SqliteStorage` Interface
 
-- [ ] 2.1 Add `getMemoriesByIds(ids: string[]): Memory[]` to the `SqliteStorage` interface in `src/storage/sqlite.ts`
-- [ ] 2.2 Add `recordAccessBatch(updates: AccessUpdate[]): void` to the interface
-- [ ] 2.3 Add `recordAccess(id: string, accessCount: number, lastAccessed: string, expiresAt: string | null | undefined, retentionTier: RetentionTier | undefined, reviewDue: string | null | undefined): void` to the interface
-- [ ] 2.4 Confirm the existing implementation in `SqliteStorage` satisfies all added signatures without changes
-- [ ] 2.5 Export `AccessUpdate` type from `src/storage/sqlite.ts` for use by callers
+- [x] 2.1 Add `getMemoriesByIds(ids: string[]): Memory[]` to the `SqliteStorage` interface in `src/storage/sqlite.ts`
+- [x] 2.2 Add `recordAccessBatch(updates: AccessUpdate[]): void` to the interface
+- [x] 2.3 Add `recordAccess(id: string, accessCount: number, lastAccessed: string, expiresAt: string | null | undefined, retentionTier: RetentionTier | undefined, reviewDue: string | null | undefined): void` to the interface
+- [x] 2.4 Confirm the existing implementation in `SqliteStorage` satisfies all added signatures without changes
+- [x] 2.5 Export `AccessUpdate` type from `src/storage/sqlite.ts` for use by callers
 
 ## 3. Refactor `search/index.ts` Feature Detection
 
-- [ ] 3.1 Remove the `typeof (this.storage.sqlite as any).getMemoriesByIds === 'function'` guard and call `getMemoriesByIds` directly
-- [ ] 3.2 Remove the `recordAccessBatch` / `recordAccess` / `touchMemory` fallback chain and call `recordAccessBatch` directly
-- [ ] 3.3 Replace all `(mem: any)` typed map callbacks with the proper `Memory` type from `src/domain/types.ts`
-- [ ] 3.4 Confirm `search/index.ts` compiles with zero `as any` and zero TS errors
+- [x] 3.1 Remove the `typeof (this.storage.sqlite as any).getMemoriesByIds === 'function'` guard and call `getMemoriesByIds` directly
+- [x] 3.2 Remove the `recordAccessBatch` / `recordAccess` / `touchMemory` fallback chain and call `recordAccessBatch` directly
+- [x] 3.3 Replace all `(mem: any)` typed map callbacks with the proper `Memory` type from `src/domain/types.ts`
+- [x] 3.4 Confirm `search/index.ts` compiles with zero `as any` and zero TS errors
 
 ## 4. Introduce `SqlParams` Type
 
-- [ ] 4.1 Add `type SqlParams = (string | number | null | Uint8Array)[]` to `src/storage/sqlite.ts` and export it
-- [ ] 4.2 Replace all `as any[]` SQL parameter arrays in `src/storage/sqlite.ts` with `SqlParams`
-- [ ] 4.3 Confirm no remaining `as any[]` in the storage layer
+- [x] 4.1 Add `type SqlParams = (string | number | null | Uint8Array)[]` to `src/storage/sqlite.ts` and export it
+- [x] 4.2 Replace all `as any[]` SQL parameter arrays in `src/storage/sqlite.ts` with `SqlParams`
+- [x] 4.3 Confirm no remaining `as any[]` in the storage layer
 
 ## 5. Remaining Cast Sites
 
-- [ ] 5.1 For each remaining `as any` in `src/domain/*`, `src/tools/*`, `src/pipeline/*`: introduce a discriminated union, type predicate, or narrowing check to replace the cast
-- [ ] 5.2 For any `as any` that is genuinely unavoidable (e.g., third-party library gap), add an `// eslint-disable-next-line @typescript-eslint/no-explicit-any` comment with a justification note
-- [ ] 5.3 Confirm zero undecorated `as any` remain in `src/`
+- [x] 5.1 For each remaining `as any` in `src/domain/*`, `src/tools/*`, `src/pipeline/*`: introduce a discriminated union, type predicate, or narrowing check to replace the cast
+- [x] 5.2 For any `as any` that is genuinely unavoidable (e.g., third-party library gap), add an `// eslint-disable-next-line @typescript-eslint/no-explicit-any` comment with a justification note
+- [x] 5.3 Confirm zero undecorated `as any` remain in `src/`
 
 ## 6. ESLint Enforcement
 
-- [ ] 6.1 Add `"@typescript-eslint/no-explicit-any": "error"` to ESLint config
-- [ ] 6.2 Run `eslint src/` and confirm zero violations (all surviving escapes are decorated with justification comments)
-- [ ] 6.3 Add ESLint check to CI pipeline (if not already present) so future violations are caught on PR
+- [x] 6.1 Add `"@typescript-eslint/no-explicit-any": "error"` to ESLint config
+- [x] 6.2 Run `eslint src/` and confirm zero violations (all surviving escapes are decorated with justification comments)
+- [x] 6.3 Add ESLint check to CI pipeline (if not already present) so future violations are caught on PR
 
 ## 7. Tests and Commit
 
-- [ ] 7.1 Run full test suite (`npm test`) and confirm no regressions
-- [ ] 7.2 Run TypeScript compiler (`tsc --noEmit`) and confirm zero errors
+- [x] 7.1 Run full test suite (`npm test`) and confirm no regressions
+- [x] 7.2 Run TypeScript compiler (`tsc --noEmit`) and confirm zero errors
 - [ ] 7.3 Commit with message: `refactor: eliminate as-any casting with typed interfaces and SqlParams (codereview2)`
 - [ ] 7.4 Push to active branch

--- a/openspec/changes/eliminate-any-type-casting/tasks.md
+++ b/openspec/changes/eliminate-any-type-casting/tasks.md
@@ -1,0 +1,45 @@
+## 1. Audit All `as any` Instances
+
+- [ ] 1.1 Run `grep -rn "as any" src/` and produce a list of all cast sites with file + line
+- [ ] 1.2 Categorize each into: (a) feature detection, (b) SQL parameters, (c) optional property access, (d) other
+- [ ] 1.3 For each category, identify the minimal interface change that eliminates the cast
+
+## 2. Extend `SqliteStorage` Interface
+
+- [ ] 2.1 Add `getMemoriesByIds(ids: string[]): Memory[]` to the `SqliteStorage` interface in `src/storage/sqlite.ts`
+- [ ] 2.2 Add `recordAccessBatch(updates: AccessUpdate[]): void` to the interface
+- [ ] 2.3 Add `recordAccess(id: string, accessCount: number, lastAccessed: string, expiresAt: string | null | undefined, retentionTier: RetentionTier | undefined, reviewDue: string | null | undefined): void` to the interface
+- [ ] 2.4 Confirm the existing implementation in `SqliteStorage` satisfies all added signatures without changes
+- [ ] 2.5 Export `AccessUpdate` type from `src/storage/sqlite.ts` for use by callers
+
+## 3. Refactor `search/index.ts` Feature Detection
+
+- [ ] 3.1 Remove the `typeof (this.storage.sqlite as any).getMemoriesByIds === 'function'` guard and call `getMemoriesByIds` directly
+- [ ] 3.2 Remove the `recordAccessBatch` / `recordAccess` / `touchMemory` fallback chain and call `recordAccessBatch` directly
+- [ ] 3.3 Replace all `(mem: any)` typed map callbacks with the proper `Memory` type from `src/domain/types.ts`
+- [ ] 3.4 Confirm `search/index.ts` compiles with zero `as any` and zero TS errors
+
+## 4. Introduce `SqlParams` Type
+
+- [ ] 4.1 Add `type SqlParams = (string | number | null | Uint8Array)[]` to `src/storage/sqlite.ts` and export it
+- [ ] 4.2 Replace all `as any[]` SQL parameter arrays in `src/storage/sqlite.ts` with `SqlParams`
+- [ ] 4.3 Confirm no remaining `as any[]` in the storage layer
+
+## 5. Remaining Cast Sites
+
+- [ ] 5.1 For each remaining `as any` in `src/domain/*`, `src/tools/*`, `src/pipeline/*`: introduce a discriminated union, type predicate, or narrowing check to replace the cast
+- [ ] 5.2 For any `as any` that is genuinely unavoidable (e.g., third-party library gap), add an `// eslint-disable-next-line @typescript-eslint/no-explicit-any` comment with a justification note
+- [ ] 5.3 Confirm zero undecorated `as any` remain in `src/`
+
+## 6. ESLint Enforcement
+
+- [ ] 6.1 Add `"@typescript-eslint/no-explicit-any": "error"` to ESLint config
+- [ ] 6.2 Run `eslint src/` and confirm zero violations (all surviving escapes are decorated with justification comments)
+- [ ] 6.3 Add ESLint check to CI pipeline (if not already present) so future violations are caught on PR
+
+## 7. Tests and Commit
+
+- [ ] 7.1 Run full test suite (`npm test`) and confirm no regressions
+- [ ] 7.2 Run TypeScript compiler (`tsc --noEmit`) and confirm zero errors
+- [ ] 7.3 Commit with message: `refactor: eliminate as-any casting with typed interfaces and SqlParams (codereview2)`
+- [ ] 7.4 Push to active branch

--- a/openspec/changes/eliminate-any-type-casting/tasks.md
+++ b/openspec/changes/eliminate-any-type-casting/tasks.md
@@ -41,5 +41,5 @@
 
 - [x] 7.1 Run full test suite (`npm test`) and confirm no regressions
 - [x] 7.2 Run TypeScript compiler (`tsc --noEmit`) and confirm zero errors
-- [ ] 7.3 Commit with message: `refactor: eliminate as-any casting with typed interfaces and SqlParams (codereview2)`
-- [ ] 7.4 Push to active branch
+- [x] 7.3 Commit with message: `refactor: eliminate as-any casting with typed interfaces and SqlParams (codereview2)`
+- [x] 7.4 Push to active branch

--- a/openspec/changes/expand-test-coverage/.openspec.yaml
+++ b/openspec/changes/expand-test-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/expand-test-coverage/design.md
+++ b/openspec/changes/expand-test-coverage/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The existing 13-file test suite covers core storage, domain logic, search, services, and middleware well. The gaps are concentrated in integration boundary modules (embedding API calls, HTTP server wiring) and small utility modules (metrics, logger) that were likely left untested because they are thin wrappers. However:
+
+- **Embedding:** `healthCheck` uses a live `embed` call; this pattern has retry implications. The degraded provider's rejection behavior is a documented contract that other services depend on (e.g., search gracefully degrades when embedding is unavailable).
+- **HTTP transport:** `createHttpServer` wires auth, rate limiting, and routing in a specific order. A mis-ordered middleware registration would be invisible without tests.
+- **Log redaction:** `redactToken` and `redactContent` are security controls. A regression in either could leak API keys or memory content to logs.
+- **MetricsCollector:** The `BoundedBuffer` circular buffer has a non-trivial overflow path; the histogram average calculation depends on correct `length` tracking.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Achieve meaningful coverage of each uncovered module's public API and documented failure modes.
+- Verify auth enforcement order in the HTTP server (health endpoint must not require auth; all others must).
+- Verify log redaction thresholds match documented behavior.
+- Verify `BoundedBuffer` wraps correctly and reports correct statistics after wrap.
+
+**Non-Goals:**
+- 100% line coverage on every file.
+- End-to-end integration tests against live OpenAI or Qdrant services.
+- CLI argument parsing exhaustiveness — focus on transport selection and fatal error paths.
+
+## Decisions
+
+### Decision: Mock `fetch` for embedding tests rather than using live API
+
+**Why:** Tests should be deterministic and not require network access. `vitest` supports `vi.spyOn(global, 'fetch')` or `vi.stubGlobal('fetch', ...)` for clean mocking.
+
+**Alternative considered:** Use a local HTTP server (msw or similar). Acceptable but heavier; `fetch` stubbing is sufficient for unit-level tests.
+
+### Decision: Use `supertest` or direct Express app for HTTP transport tests
+
+**Why:** `createHttpServer` returns an Express app. `supertest(app)` allows route and response assertions without binding to a port. Zero network overhead, no port conflicts in CI.
+
+**Alternative considered:** Instantiate a real server on a random port. Adds complexity without value at unit-test level.
+
+### Decision: Expand health index tests with stub sub-components
+
+**Why:** The existing health test is likely a smoke test. Degraded-component scenarios (Qdrant unavailable, embedding degraded) are the exact conditions that trigger `degraded` status — these must be verified explicitly because the HTTP `/health` route exposes this status externally.
+
+## Risks / Trade-offs
+
+- **[Risk] CLI tests are harder to unit-test** — `src/cli/index.ts` likely calls `process.exit()` on errors, which terminates the test runner. Mitigation: spy on `process.exit`, or use a child-process integration test with expected exit code assertions.
+- **[Risk] HTTP transport tests must not accidentally start a real server** — Mitigation: use `supertest` in-process mode only; never call `.listen()` in tests.

--- a/openspec/changes/expand-test-coverage/proposal.md
+++ b/openspec/changes/expand-test-coverage/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+codereview2.md identifies six modules with no test coverage despite being critical to system correctness and security:
+
+- `src/embedding/index.ts` — OpenAI API integration: retry/error handling, degraded provider fallback, health check behavior
+- `src/transport/http.ts` — HTTP server: route correctness, auth enforcement on all guarded endpoints, health endpoint availability without auth
+- `src/health/metrics.ts` — MetricsCollector: counter/histogram/gauge accumulation, bounded buffer overflow, `getMetrics` output shape
+- `src/health/logger.ts` — `createLogger`, `redactContent`, `redactToken` — log redaction is a security control and must be verified
+- `src/cli/index.ts` — CLI entry point: transport selection, config validation errors, clean shutdown
+- `src/health/index.ts` — Existing test exists but is noted as likely needing expansion (component isolation, degraded sub-component handling)
+
+Each of these is either on a critical path (auth, embedding, HTTP routing) or is a security control (log redaction). Untested code in these areas means regressions can ship silently.
+
+## What Changes
+
+- Add a `src/embedding/index.test.ts` covering `OpenAIEmbeddingProvider` (success, API error, network failure, batch ordering), `DegradedEmbeddingProvider` (rejects all embed calls, healthCheck returns false), and `createEmbeddingProvider` (degraded fallback on missing credentials).
+- Add a `src/transport/http.test.ts` covering all routes: health (unauthenticated), tool POST (authenticated), resource GET (authenticated), metrics GET (conditionally enabled), 401 on missing/invalid token.
+- Add a `src/health/metrics.test.ts` covering counter increment, histogram bounded buffer behavior (overflow wraps, avg computation), gauge set/overwrite, disabled collector returns empty, `getMetrics` output shape.
+- Add a `src/health/logger.test.ts` covering `redactContent` truncation boundary, `redactToken` short/long token handling, `createLogger` respects log level config.
+- Add a `src/cli/index.test.ts` or integration smoke test covering CLI transport flag routing and config validation error exit codes.
+- Expand `src/health/index.test.ts` to cover degraded sub-component scenarios (Qdrant unavailable, embedding degraded, SQLite initialized).
+
+## Capabilities
+
+### New Capabilities
+- `embedding-provider-test-coverage`: Embedding provider behavior is verified under success, failure, degraded, and health-check scenarios.
+- `http-transport-test-coverage`: HTTP server routes, auth enforcement, and conditional endpoints are verified.
+- `metrics-logger-test-coverage`: MetricsCollector and logger utilities (including redaction) are verified.
+
+### Modified Capabilities
+- `health-service-test-coverage`: Health index tests expanded to cover degraded sub-components.
+
+## Impact
+
+- New test files: `src/embedding/index.test.ts`, `src/transport/http.test.ts`, `src/health/metrics.test.ts`, `src/health/logger.test.ts`, `src/cli/index.test.ts`
+- Modified test file: `src/health/index.test.ts`
+- No production code changes. Test infrastructure only.
+- Coverage gates (if configured) will reflect the new coverage.

--- a/openspec/changes/expand-test-coverage/tasks.md
+++ b/openspec/changes/expand-test-coverage/tasks.md
@@ -61,5 +61,5 @@
 
 - [x] 7.1 Run `npm test` and confirm all new tests pass
 - [x] 7.2 Run coverage report and confirm all six target modules have meaningful coverage (>80% line)
-- [ ] 7.3 Commit with message: `test: add coverage for embedding, http transport, metrics, logger, health, and cli (codereview2)`
-- [ ] 7.4 Push to active branch
+- [x] 7.3 Commit with message: `test: add coverage for embedding, http transport, metrics, logger, health, and cli (codereview2)`
+- [x] 7.4 Push to active branch

--- a/openspec/changes/expand-test-coverage/tasks.md
+++ b/openspec/changes/expand-test-coverage/tasks.md
@@ -1,0 +1,65 @@
+## 1. Embedding Provider Tests (`src/embedding/index.test.ts`)
+
+- [ ] 1.1 Stub `global.fetch` with `vi.stubGlobal` to return a successful embeddings response; assert `OpenAIEmbeddingProvider.embed` returns the correct vector
+- [ ] 1.2 Assert `embedBatch` preserves sort order when the API returns items out of index order
+- [ ] 1.3 Stub `fetch` to throw a network error; assert `embed` throws an `embeddingUnavailable` BrainError
+- [ ] 1.4 Stub `fetch` to return HTTP 429; assert `embed` throws an `embeddingUnavailable` BrainError with the status code in the message
+- [ ] 1.5 Assert `OpenAIEmbeddingProvider.healthCheck` returns `true` when `embed` succeeds and `false` when it throws
+- [ ] 1.6 Assert `DegradedEmbeddingProvider.embed` throws `embeddingUnavailable`
+- [ ] 1.7 Assert `DegradedEmbeddingProvider.embedBatch` throws `embeddingUnavailable`
+- [ ] 1.8 Assert `DegradedEmbeddingProvider.healthCheck` returns `false`
+- [ ] 1.9 Assert `createEmbeddingProvider` returns a `DegradedEmbeddingProvider` when the API key env var is absent
+- [ ] 1.10 Assert `createEmbeddingProvider` throws on unknown `config.embedding.provider` values
+
+## 2. HTTP Transport Tests (`src/transport/http.test.ts`)
+
+- [ ] 2.1 Create a minimal `BrainConfig` fixture and stub `ToolContext` / `ResourceHandler` / `HealthService`
+- [ ] 2.2 Assert `GET /health` returns 200 with a health body when no auth token is provided (unauthenticated)
+- [ ] 2.3 Assert `GET /health` returns 503 when the health stub reports `status: 'unhealthy'`
+- [ ] 2.4 Assert `POST /tool/:name` returns 401 when `Authorization` header is absent (auth is configured)
+- [ ] 2.5 Assert `POST /tool/:name` returns 401 when an invalid bearer token is provided
+- [ ] 2.6 Assert `POST /tool/:name` with a valid bearer token calls `handleTool` and returns its result
+- [ ] 2.7 Assert `GET /resource?uri=<uri>` returns 400 when `uri` query param is absent
+- [ ] 2.8 Assert `GET /resource?uri=<uri>` with valid token calls `resources.handle` and returns its result
+- [ ] 2.9 Assert `GET /metrics` returns 404 (or is unregistered) when `observability.metrics_enabled` is false
+- [ ] 2.10 Assert `GET /metrics` returns a plain-text metrics body when `observability.metrics_enabled` is true
+
+## 3. MetricsCollector Tests (`src/health/metrics.test.ts`)
+
+- [ ] 3.1 Assert `incCounter` accumulates correctly across multiple calls
+- [ ] 3.2 Assert `incCounter` with custom `amount` adds the correct increment
+- [ ] 3.3 Assert `recordHistogram` stores values and `getMetrics` returns correct `_avg` and `_count`
+- [ ] 3.4 Assert `BoundedBuffer` wraps correctly at capacity: after `capacity + N` pushes, `values()` returns exactly `capacity` items and `_avg` reflects the most recent window
+- [ ] 3.5 Assert `setGauge` overwrites previous value; `getMetrics` returns the latest value
+- [ ] 3.6 Assert a disabled `MetricsCollector` (`metrics_enabled: false`) silently ignores all record calls and returns `[]` from `getMetrics`
+- [ ] 3.7 Assert `getMetrics` returns entries with correct `name`, `type`, and `value` shape
+
+## 4. Logger / Redaction Tests (`src/health/logger.test.ts`)
+
+- [ ] 4.1 Assert `redactContent` returns the full string when `content.length <= 50`
+- [ ] 4.2 Assert `redactContent` returns a string truncated to 50 chars + `...[redacted]` when content exceeds 50 chars
+- [ ] 4.3 Assert `redactToken` returns `***` when token length is <= 8
+- [ ] 4.4 Assert `redactToken` returns `first4...last4` format when token length > 8
+- [ ] 4.5 Assert `createLogger` returns a pino logger with the `level` set from config
+- [ ] 4.6 Assert `createLogger` passes `redact` paths to pino when `config.security.log_redaction` is true
+- [ ] 4.7 Assert `createLogger` passes `undefined` for `redact` when `config.security.log_redaction` is false
+
+## 5. Health Service Expansion (`src/health/index.test.ts`)
+
+- [ ] 5.1 Assert health check returns `status: 'degraded'` when embedding provider is in degraded mode but SQLite and Qdrant are healthy
+- [ ] 5.2 Assert health check returns `status: 'degraded'` when Qdrant is unavailable but SQLite is healthy
+- [ ] 5.3 Assert health check returns `status: 'unhealthy'` when SQLite is unavailable
+- [ ] 5.4 Assert health check result is cached for 30 seconds (second call within window does not re-invoke sub-checks)
+
+## 6. CLI Smoke Test (`src/cli/index.test.ts`)
+
+- [ ] 6.1 Spy on `process.exit`; import CLI entry with missing required config and assert it exits with code 1
+- [ ] 6.2 Assert CLI logs a human-readable error message before exiting on config validation failure
+- [ ] 6.3 (Optional) Assert `--transport stdio` and `--transport http` flags route to the correct transport initializer
+
+## 7. CI and Commit
+
+- [ ] 7.1 Run `npm test` and confirm all new tests pass
+- [ ] 7.2 Run coverage report and confirm all six target modules have meaningful coverage (>80% line)
+- [ ] 7.3 Commit with message: `test: add coverage for embedding, http transport, metrics, logger, health, and cli (codereview2)`
+- [ ] 7.4 Push to active branch

--- a/openspec/changes/expand-test-coverage/tasks.md
+++ b/openspec/changes/expand-test-coverage/tasks.md
@@ -1,65 +1,65 @@
 ## 1. Embedding Provider Tests (`src/embedding/index.test.ts`)
 
-- [ ] 1.1 Stub `global.fetch` with `vi.stubGlobal` to return a successful embeddings response; assert `OpenAIEmbeddingProvider.embed` returns the correct vector
-- [ ] 1.2 Assert `embedBatch` preserves sort order when the API returns items out of index order
-- [ ] 1.3 Stub `fetch` to throw a network error; assert `embed` throws an `embeddingUnavailable` BrainError
-- [ ] 1.4 Stub `fetch` to return HTTP 429; assert `embed` throws an `embeddingUnavailable` BrainError with the status code in the message
-- [ ] 1.5 Assert `OpenAIEmbeddingProvider.healthCheck` returns `true` when `embed` succeeds and `false` when it throws
-- [ ] 1.6 Assert `DegradedEmbeddingProvider.embed` throws `embeddingUnavailable`
-- [ ] 1.7 Assert `DegradedEmbeddingProvider.embedBatch` throws `embeddingUnavailable`
-- [ ] 1.8 Assert `DegradedEmbeddingProvider.healthCheck` returns `false`
-- [ ] 1.9 Assert `createEmbeddingProvider` returns a `DegradedEmbeddingProvider` when the API key env var is absent
-- [ ] 1.10 Assert `createEmbeddingProvider` throws on unknown `config.embedding.provider` values
+- [x] 1.1 Stub `global.fetch` with `vi.stubGlobal` to return a successful embeddings response; assert `OpenAIEmbeddingProvider.embed` returns the correct vector
+- [x] 1.2 Assert `embedBatch` preserves sort order when the API returns items out of index order
+- [x] 1.3 Stub `fetch` to throw a network error; assert `embed` throws an `embeddingUnavailable` BrainError
+- [x] 1.4 Stub `fetch` to return HTTP 429; assert `embed` throws an `embeddingUnavailable` BrainError with the status code in the message
+- [x] 1.5 Assert `OpenAIEmbeddingProvider.healthCheck` returns `true` when `embed` succeeds and `false` when it throws
+- [x] 1.6 Assert `DegradedEmbeddingProvider.embed` throws `embeddingUnavailable`
+- [x] 1.7 Assert `DegradedEmbeddingProvider.embedBatch` throws `embeddingUnavailable`
+- [x] 1.8 Assert `DegradedEmbeddingProvider.healthCheck` returns `false`
+- [x] 1.9 Assert `createEmbeddingProvider` returns a `DegradedEmbeddingProvider` when the API key env var is absent
+- [x] 1.10 Assert `createEmbeddingProvider` throws on unknown `config.embedding.provider` values
 
 ## 2. HTTP Transport Tests (`src/transport/http.test.ts`)
 
-- [ ] 2.1 Create a minimal `BrainConfig` fixture and stub `ToolContext` / `ResourceHandler` / `HealthService`
-- [ ] 2.2 Assert `GET /health` returns 200 with a health body when no auth token is provided (unauthenticated)
-- [ ] 2.3 Assert `GET /health` returns 503 when the health stub reports `status: 'unhealthy'`
-- [ ] 2.4 Assert `POST /tool/:name` returns 401 when `Authorization` header is absent (auth is configured)
-- [ ] 2.5 Assert `POST /tool/:name` returns 401 when an invalid bearer token is provided
-- [ ] 2.6 Assert `POST /tool/:name` with a valid bearer token calls `handleTool` and returns its result
-- [ ] 2.7 Assert `GET /resource?uri=<uri>` returns 400 when `uri` query param is absent
-- [ ] 2.8 Assert `GET /resource?uri=<uri>` with valid token calls `resources.handle` and returns its result
-- [ ] 2.9 Assert `GET /metrics` returns 404 (or is unregistered) when `observability.metrics_enabled` is false
-- [ ] 2.10 Assert `GET /metrics` returns a plain-text metrics body when `observability.metrics_enabled` is true
+- [x] 2.1 Create a minimal `BrainConfig` fixture and stub `ToolContext` / `ResourceHandler` / `HealthService`
+- [x] 2.2 Assert `GET /health` returns 200 with a health body when no auth token is provided (unauthenticated)
+- [x] 2.3 Assert `GET /health` returns 503 when the health stub reports `status: 'unhealthy'`
+- [x] 2.4 Assert `POST /tool/:name` returns 401 when `Authorization` header is absent (auth is configured)
+- [x] 2.5 Assert `POST /tool/:name` returns 401 when an invalid bearer token is provided
+- [x] 2.6 Assert `POST /tool/:name` with a valid bearer token calls `handleTool` and returns its result
+- [x] 2.7 Assert `GET /resource?uri=<uri>` returns 400 when `uri` query param is absent
+- [x] 2.8 Assert `GET /resource?uri=<uri>` with valid token calls `resources.handle` and returns its result
+- [x] 2.9 Assert `GET /metrics` returns 404 (or is unregistered) when `observability.metrics_enabled` is false
+- [x] 2.10 Assert `GET /metrics` returns a plain-text metrics body when `observability.metrics_enabled` is true
 
 ## 3. MetricsCollector Tests (`src/health/metrics.test.ts`)
 
-- [ ] 3.1 Assert `incCounter` accumulates correctly across multiple calls
-- [ ] 3.2 Assert `incCounter` with custom `amount` adds the correct increment
-- [ ] 3.3 Assert `recordHistogram` stores values and `getMetrics` returns correct `_avg` and `_count`
-- [ ] 3.4 Assert `BoundedBuffer` wraps correctly at capacity: after `capacity + N` pushes, `values()` returns exactly `capacity` items and `_avg` reflects the most recent window
-- [ ] 3.5 Assert `setGauge` overwrites previous value; `getMetrics` returns the latest value
-- [ ] 3.6 Assert a disabled `MetricsCollector` (`metrics_enabled: false`) silently ignores all record calls and returns `[]` from `getMetrics`
-- [ ] 3.7 Assert `getMetrics` returns entries with correct `name`, `type`, and `value` shape
+- [x] 3.1 Assert `incCounter` accumulates correctly across multiple calls
+- [x] 3.2 Assert `incCounter` with custom `amount` adds the correct increment
+- [x] 3.3 Assert `recordHistogram` stores values and `getMetrics` returns correct `_avg` and `_count`
+- [x] 3.4 Assert `BoundedBuffer` wraps correctly at capacity: after `capacity + N` pushes, `values()` returns exactly `capacity` items and `_avg` reflects the most recent window
+- [x] 3.5 Assert `setGauge` overwrites previous value; `getMetrics` returns the latest value
+- [x] 3.6 Assert a disabled `MetricsCollector` (`metrics_enabled: false`) silently ignores all record calls and returns `[]` from `getMetrics`
+- [x] 3.7 Assert `getMetrics` returns entries with correct `name`, `type`, and `value` shape
 
 ## 4. Logger / Redaction Tests (`src/health/logger.test.ts`)
 
-- [ ] 4.1 Assert `redactContent` returns the full string when `content.length <= 50`
-- [ ] 4.2 Assert `redactContent` returns a string truncated to 50 chars + `...[redacted]` when content exceeds 50 chars
-- [ ] 4.3 Assert `redactToken` returns `***` when token length is <= 8
-- [ ] 4.4 Assert `redactToken` returns `first4...last4` format when token length > 8
-- [ ] 4.5 Assert `createLogger` returns a pino logger with the `level` set from config
-- [ ] 4.6 Assert `createLogger` passes `redact` paths to pino when `config.security.log_redaction` is true
-- [ ] 4.7 Assert `createLogger` passes `undefined` for `redact` when `config.security.log_redaction` is false
+- [x] 4.1 Assert `redactContent` returns the full string when `content.length <= 50`
+- [x] 4.2 Assert `redactContent` returns a string truncated to 50 chars + `...[redacted]` when content exceeds 50 chars
+- [x] 4.3 Assert `redactToken` returns `***` when token length is <= 8
+- [x] 4.4 Assert `redactToken` returns `first4...last4` format when token length > 8
+- [x] 4.5 Assert `createLogger` returns a pino logger with the `level` set from config
+- [x] 4.6 Assert `createLogger` passes `redact` paths to pino when `config.security.log_redaction` is true
+- [x] 4.7 Assert `createLogger` passes `undefined` for `redact` when `config.security.log_redaction` is false
 
 ## 5. Health Service Expansion (`src/health/index.test.ts`)
 
-- [ ] 5.1 Assert health check returns `status: 'degraded'` when embedding provider is in degraded mode but SQLite and Qdrant are healthy
-- [ ] 5.2 Assert health check returns `status: 'degraded'` when Qdrant is unavailable but SQLite is healthy
-- [ ] 5.3 Assert health check returns `status: 'unhealthy'` when SQLite is unavailable
-- [ ] 5.4 Assert health check result is cached for 30 seconds (second call within window does not re-invoke sub-checks)
+- [x] 5.1 Assert health check returns `status: 'degraded'` when embedding provider is in degraded mode but SQLite and Qdrant are healthy
+- [x] 5.2 Assert health check returns `status: 'degraded'` when Qdrant is unavailable but SQLite is healthy
+- [x] 5.3 Assert health check returns `status: 'unhealthy'` when SQLite is unavailable
+- [x] 5.4 Assert health check result is cached for 30 seconds (second call within window does not re-invoke sub-checks)
 
 ## 6. CLI Smoke Test (`src/cli/index.test.ts`)
 
-- [ ] 6.1 Spy on `process.exit`; import CLI entry with missing required config and assert it exits with code 1
-- [ ] 6.2 Assert CLI logs a human-readable error message before exiting on config validation failure
-- [ ] 6.3 (Optional) Assert `--transport stdio` and `--transport http` flags route to the correct transport initializer
+- [x] 6.1 Spy on `process.exit`; import CLI entry with missing required config and assert it exits with code 1
+- [x] 6.2 Assert CLI logs a human-readable error message before exiting on config validation failure
+- [x] 6.3 Assert CLI `server start --stdio` delegates to the stdio server initializer path
 
 ## 7. CI and Commit
 
-- [ ] 7.1 Run `npm test` and confirm all new tests pass
-- [ ] 7.2 Run coverage report and confirm all six target modules have meaningful coverage (>80% line)
+- [x] 7.1 Run `npm test` and confirm all new tests pass
+- [x] 7.2 Run coverage report and confirm all six target modules have meaningful coverage (>80% line)
 - [ ] 7.3 Commit with message: `test: add coverage for embedding, http transport, metrics, logger, health, and cli (codereview2)`
 - [ ] 7.4 Push to active branch

--- a/openspec/changes/fix-collection-scope-consistency/.openspec.yaml
+++ b/openspec/changes/fix-collection-scope-consistency/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-21

--- a/openspec/changes/fix-collection-scope-consistency/design.md
+++ b/openspec/changes/fix-collection-scope-consistency/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The review found three related collection-scope defects. Search semantics are inconsistent when `collection` is omitted, because fulltext search stays namespace-wide while vector-backed search silently falls back to `general`. Exact checksum deduplication is namespace-scoped instead of collection-scoped. The `collection://{name}` resource also truncates the newest namespace results before filtering, which can omit valid collection members.
+
+These are cross-cutting problems across search, storage, pipeline, tools, and resources. The design needs to align read and write behavior without forcing a disruptive storage migration.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define one consistent rule for namespace-versus-collection behavior across retrieval and deduplication.
+- Preserve the current API shape where `collection` remains optional.
+- Eliminate silent fallback to `general` when omitted-collection retrieval is requested.
+- Make collection resources query collection-scoped rows directly and support complete results.
+
+**Non-Goals:**
+- Redesigning the namespace model or changing the public tool schemas.
+- Repacking all vectors into a new Qdrant collection layout.
+- Changing dedup scoring thresholds beyond scope alignment.
+
+## Decisions
+
+1. Treat omitted `collection` as namespace-wide behavior at the service contract layer.
+- Decision: `search` and `recall` without a `collection` SHALL operate across all collections in the namespace, regardless of backend.
+- Rationale: this matches current fulltext behavior and user expectations from the optional parameter.
+- Alternative considered: redefine omitted `collection` to mean `general`. Rejected because it would silently narrow results and formalize the current bug.
+
+2. Implement namespace-wide vector retrieval as fan-out plus merge, not a storage migration.
+- Decision: when no collection is supplied, the search layer will enumerate known collections in the namespace, query each vector collection, and merge/rerank results before hydration.
+- Rationale: it preserves the existing Qdrant layout and avoids a data migration or dual-write transition.
+- Alternative considered: migrate to one Qdrant collection per namespace. Rejected because it is more invasive and unnecessary for this correctness fix.
+
+3. Make exact checksum dedup collection-aware.
+- Decision: exact deduplication SHALL key on `(namespace, collection, checksum)` instead of `(namespace, checksum)`.
+- Rationale: write behavior should respect the same collection boundary that near-dedup and collection resources use.
+- Alternative considered: keep exact dedup namespace-wide and document it. Rejected because it would preserve a surprising mismatch between exact and semantic dedup paths.
+
+4. Add direct collection-scoped listing in storage for resources.
+- Decision: the resource layer will use a dedicated collection query with pagination instead of loading a namespace slice and filtering in memory.
+- Rationale: the current truncation-before-filtering behavior cannot produce correct results for larger namespaces.
+- Alternative considered: increase the namespace slice from 50 to a larger number. Rejected because it remains incomplete and unbounded.
+
+## Risks / Trade-offs
+
+- [Namespace-wide vector fan-out can be slower in namespaces with many collections] -> Mitigation: query only collections known to SQLite, cap per-collection fetch size, and merge only the top candidates needed for the final limit.
+- [Collection-aware exact dedup changes write outcomes for existing clients] -> Mitigation: treat the change as an intentional contract correction and cover it with regression tests.
+- [Merged ranking across collections can introduce ordering edge cases] -> Mitigation: preserve the existing hydration and ranking pipeline after fan-out so collection origin does not change score normalization rules unnecessarily.
+
+## Migration Plan
+
+1. Add storage helpers for collection-scoped checksum lookup and collection-scoped listing with pagination.
+2. Update search service and Qdrant access paths to support namespace-wide omitted-collection retrieval.
+3. Update write pipeline exact dedup to use collection-aware lookup.
+4. Update collection resource handling to use direct collection queries.
+5. Add regression tests for omitted-collection semantic/hybrid search, cross-collection exact dedup, and collection resource completeness.
+
+## Open Questions
+
+- Should namespace-wide semantic fan-out remain purely sequential at first, or should it issue collection queries concurrently once correctness is in place?

--- a/openspec/changes/fix-collection-scope-consistency/proposal.md
+++ b/openspec/changes/fix-collection-scope-consistency/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Collection scoping is currently inconsistent across search, deduplication, and resource reads. When `collection` is omitted, fulltext search behaves namespace-wide while vector-backed search falls back to `general`; exact checksum dedup ignores collection boundaries; and `collection://{name}` can omit older matching memories because it truncates before filtering.
+
+## What Changes
+
+- Define one consistent collection-scope contract for `search`, `recall`, and deduplication.
+- Require omitted-collection search behavior to remain namespace-wide across semantic, fulltext, and hybrid retrieval.
+- Align exact deduplication scope with the chosen collection contract so write behavior matches read behavior.
+- Define collection resource behavior to query collection-scoped results directly, with pagination instead of namespace truncation.
+- Add regression coverage for omitted-collection search, cross-collection dedup, and collection resource completeness.
+
+## Capabilities
+
+### New Capabilities
+- `collection-scope-consistency`: defines consistent namespace-versus-collection behavior across search, recall, deduplication, and collection resources.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected code: `src/search`, `src/storage/qdrant.ts`, `src/storage/sqlite.ts`, `src/pipeline/index.ts`, `src/resources/index.ts`, and related tests.
+- API behavior: `search`, `recall`, and `collection://{name}` become explicit and consistency-preserving when `collection` is omitted or when duplicate content exists across collections.
+- Data behavior: prevents silent misses in non-`general` collections and removes ambiguity around cross-collection exact deduplication.

--- a/openspec/changes/fix-collection-scope-consistency/specs/collection-scope-consistency/spec.md
+++ b/openspec/changes/fix-collection-scope-consistency/specs/collection-scope-consistency/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Omitted-collection retrieval searches the full namespace
+When a client omits `collection`, the system SHALL evaluate semantic, fulltext, and hybrid retrieval across all collections in the requested namespace instead of narrowing to `general`.
+
+#### Scenario: Semantic search without a collection includes non-general collections
+- **WHEN** a namespace contains relevant memories in `general` and in another collection and a client performs semantic search without supplying `collection`
+- **THEN** the retrieval path searches all collections in that namespace
+- **AND** eligible results from non-`general` collections remain available for ranking and hydration
+
+#### Scenario: Hybrid search uses the same scope for vector and fulltext inputs
+- **WHEN** a client performs hybrid search without supplying `collection`
+- **THEN** the semantic candidate set and the fulltext candidate set are both gathered from the same namespace-wide collection scope
+- **AND** the final ranking does not silently exclude non-`general` collections
+
+### Requirement: Exact deduplication respects collection boundaries
+Exact checksum deduplication SHALL be scoped to the target namespace and target collection so identical content in different collections does not collapse into one write decision.
+
+#### Scenario: Same checksum in a different collection remains addable
+- **WHEN** a memory with checksum `X` already exists in namespace `N` and collection `A`
+- **AND** a client stores the same normalized content in namespace `N` and collection `B`
+- **THEN** exact deduplication does not return a terminal match from collection `A`
+- **AND** the pipeline may continue with add-or-update behavior within collection `B`
+
+#### Scenario: Same checksum in the same collection remains a no-op
+- **WHEN** a memory with checksum `X` already exists in namespace `N` and collection `A`
+- **AND** a client stores the same normalized content again in namespace `N` and collection `A`
+- **THEN** the write decision returns a terminal exact-dedup no-op for that existing memory
+
+### Requirement: Collection resources return complete collection-scoped results
+Collection resources SHALL query collection membership directly and SHALL support pagination so results are not truncated by unrelated namespace activity.
+
+#### Scenario: Collection resource does not truncate before filtering
+- **WHEN** a namespace contains more recent memories in other collections than in the requested collection
+- **AND** a client reads `collection://{name}`
+- **THEN** the resource query selects rows for the requested collection directly
+- **AND** older matching memories in that collection remain retrievable
+
+#### Scenario: Collection resource paginates large collections
+- **WHEN** a requested collection contains more results than a single page can return
+- **THEN** the resource response returns a deterministic page of collection-scoped results
+- **AND** the response includes the cursor or pagination contract needed to request the next page

--- a/openspec/changes/fix-collection-scope-consistency/tasks.md
+++ b/openspec/changes/fix-collection-scope-consistency/tasks.md
@@ -1,0 +1,14 @@
+## 1. Collection-scoped storage and query helpers
+
+- [ ] 1.1 Add SQLite helpers for checksum lookup by `(namespace, collection, checksum)` and for listing memories directly by collection with pagination support.
+- [ ] 1.2 Extend vector search helpers so omitted-collection retrieval can enumerate namespace collections and merge candidates without falling back to `general`.
+
+## 2. Service and resource behavior
+
+- [ ] 2.1 Update search and recall flows so omitted-collection semantic, fulltext, and hybrid retrieval all use the same namespace-wide scope.
+- [ ] 2.2 Update exact dedup in the write pipeline and `collection://{name}` resource handling to respect collection-scoped behavior and complete pagination.
+
+## 3. Validation
+
+- [ ] 3.1 Add regression tests for omitted-collection semantic/hybrid search, cross-collection exact dedup, and collection resource completeness.
+- [ ] 3.2 Run `npm run lint`, `npm test`, and `npm run build` to verify collection-scope behavior end to end.

--- a/openspec/changes/harden-post-restore-reconciliation/.openspec.yaml
+++ b/openspec/changes/harden-post-restore-reconciliation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-21

--- a/openspec/changes/harden-post-restore-reconciliation/design.md
+++ b/openspec/changes/harden-post-restore-reconciliation/design.md
@@ -1,0 +1,59 @@
+## Context
+
+The recent restore work made SQLite activation and vector readiness explicit, but the restore flow still treats some post-activation vector steps as fatal even after restored metadata is already live in-process. The current reconciliation loop also records successful sync state in memory and only flushes at the end of the batch, which makes partial progress less durable than it should be when a later vector upsert fails.
+
+This follow-up change needs to harden restore semantics without changing the broader SQLite-first recovery model. SQLite remains the restore source of truth, vector state remains derived, and the immediate goal is to make failure boundaries explicit and operationally safe.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Preserve restore activation success once restored SQLite state is active in the running process.
+- Treat post-activation vector cleanup and rebuild failures as degraded reconciliation outcomes instead of full restore failure.
+- Make successful reconciliation progress durable across partial failures.
+- Ensure restore lifecycle and concurrency guards are always cleaned up safely.
+
+**Non-Goals:**
+- Changing the backup artifact format or introducing bundled Qdrant snapshots.
+- Moving reconciliation to a background worker or defining a new large-restore async contract.
+- Redesigning non-restore write-path synchronization or MCP transport behavior in this change.
+
+## Decisions
+
+1. Treat SQLite activation as the restore success boundary.
+- Decision: once `reloadSqliteFromDisk()` succeeds, restore semantics treat metadata activation as complete even if later vector invalidation or reconciliation work degrades.
+- Rationale: the running process has already crossed the authoritative SQLite recovery boundary, so reporting total restore failure is misleading and operationally unsafe.
+- Alternative considered: keep returning full restore failure after post-activation vector errors. Rejected because it contradicts the activated runtime state and obscures the correct operator action.
+
+2. Keep vector recovery explicit and best-effort after activation.
+- Decision: failures in vector clearing or reconciliation after SQLite activation will leave restored rows unsynced and return explicit degraded readiness instead of negating activation.
+- Rationale: Qdrant is derived state in this architecture, so vector recovery problems should degrade semantic readiness, not invalidate authoritative metadata activation.
+- Alternative considered: trust pre-existing vectors when clear or rebuild fails. Rejected because it would reintroduce silent drift between restored metadata and vector state.
+
+3. Persist reconciliation progress incrementally.
+- Decision: successful vector rebuild progress will be flushed durably before returning from a partial reconciliation failure, so later retries resume from the remaining unsynced set.
+- Rationale: it avoids repeating already completed rebuild work after restart and keeps sync markers aligned with actual Qdrant progress.
+- Alternative considered: keep flushing only at the end of the batch. Rejected because it loses successful progress if a later upsert fails before the batch flush.
+
+4. Collapse restore guard cleanup into a single fail-safe path.
+- Decision: restore lifecycle acquisition and the in-progress flag will be arranged so every failure path releases concurrency state deterministically.
+- Rationale: restore is a rare but high-impact operation, so sticky in-progress state is worse than a normal request failure.
+- Alternative considered: leave the current ordering and rely on narrow trigger windows. Rejected because a single pre-try failure can block all later restores until restart.
+
+## Risks / Trade-offs
+
+- [Qdrant may still contain stale vectors when post-activation clear fails] -> Mitigation: keep vector reconciliation explicitly degraded/pending and never report full semantic readiness until recovery is complete.
+- [Incremental flushes during reconciliation add overhead] -> Mitigation: flush per completed chunk or failure boundary rather than per unrelated operation.
+- [Operators may interpret activated-but-degraded restore as full readiness] -> Mitigation: preserve clear restore result fields and health semantics that separate activation from reconciliation.
+
+## Migration Plan
+
+1. Refactor restore control flow so activation success is preserved once runtime SQLite reload completes.
+2. Make post-activation vector clear and rebuild steps degrade restore readiness instead of failing the whole operation.
+3. Persist successful reconciliation progress before returning pending status on partial failure.
+4. Add regression tests for post-activation clear failure, partial rebuild durability, and restore guard cleanup.
+5. Rollback strategy: revert to the prior restore implementation if needed; no backup format migration is involved.
+
+## Open Questions
+
+- Should a future follow-up move pending reconciliation to a background retry loop for large restores?
+- Should restore emit additional audit or metrics events for “activated but degraded” outcomes beyond the existing health/reporting surfaces?

--- a/openspec/changes/harden-post-restore-reconciliation/proposal.md
+++ b/openspec/changes/harden-post-restore-reconciliation/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Restore now distinguishes SQLite activation from vector readiness, but it still has post-activation failure paths that can return overall restore failure after restored metadata is already live. It also leaves reconciliation progress less durable than it should be when vector rebuild work fails partway through.
+
+## What Changes
+
+- Harden restore so once SQLite activation succeeds, subsequent vector invalidation or reconciliation failures are reported as explicit degraded readiness instead of negating restore activation.
+- Make post-restore reconciliation progress durable so successful vector rebuild work is preserved even if a later upsert in the same run fails.
+- Tighten restore lifecycle handling so restore serialization state is always cleaned up safely, including lock-acquisition and early-failure paths.
+- Add regression coverage for post-activation vector-clear failures, partial reconciliation progress, and restore lock cleanup behavior.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+- `dual-store-backup-restore-consistency`: restore must preserve explicit activated-but-degraded semantics and durable reconciliation progress when vector recovery work fails after SQLite activation.
+- `backup-restore-runtime-activation`: restore activation semantics are tightened so activation success is not masked by later post-activation failures and restore serialization remains fail-safe.
+
+## Impact
+
+- Affected code: `src/backup/index.ts`, `src/storage/index.ts`, `src/storage/qdrant.ts`, `src/storage/sqlite.ts`, and restore-related tests.
+- API behavior: restore responses become stricter about activated-versus-degraded outcomes after SQLite is live.
+- Reliability: reduces sticky restore lock failures and prevents successful reconciliation work from being lost on partial post-restore failures.

--- a/openspec/changes/harden-post-restore-reconciliation/specs/backup-restore-runtime-activation/spec.md
+++ b/openspec/changes/harden-post-restore-reconciliation/specs/backup-restore-runtime-activation/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Restore serialization SHALL fail safe
+The system SHALL release restore lifecycle guards and in-progress state when a restore attempt fails before activation fully completes.
+
+#### Scenario: Restore setup fails before activation completes
+- **WHEN** a restore attempt fails while establishing restore serialization or before activation finishes
+- **THEN** the failed attempt does not leave restore state stuck in progress
+- **AND** a later restore attempt can start normally
+
+### Requirement: Activation success SHALL not be masked by later degraded work
+A restore that has already activated runtime SQLite state MUST NOT be reported as a complete failure solely because later post-activation recovery work fails.
+
+#### Scenario: Post-activation work fails
+- **WHEN** runtime SQLite activation succeeds and later post-activation vector recovery work fails
+- **THEN** the system does not report that activation itself failed
+- **AND** the restore response preserves explicit activation success metadata
+- **AND** the remaining recovery work is surfaced through degraded readiness details

--- a/openspec/changes/harden-post-restore-reconciliation/specs/dual-store-backup-restore-consistency/spec.md
+++ b/openspec/changes/harden-post-restore-reconciliation/specs/dual-store-backup-restore-consistency/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Post-activation vector recovery failures SHALL preserve activated state
+When a restore has already activated restored SQLite state in the running process, later vector cleanup or reconciliation failures SHALL be surfaced as explicit degraded vector readiness instead of negating metadata activation.
+
+#### Scenario: Vector cleanup fails after SQLite activation
+- **WHEN** a restore successfully activates restored SQLite state and subsequent vector clearing or rebuild work fails
+- **THEN** the restore result reports metadata activation success
+- **AND** the result reports vector reconciliation as pending or degraded
+- **AND** semantic health does not report the service as fully ready until vector recovery completes
+
+### Requirement: Reconciliation progress SHALL remain durable across partial failure
+The system SHALL persist successful post-restore reconciliation progress before returning a pending reconciliation outcome from a later failure in the same run.
+
+#### Scenario: Reconciliation fails after some restored memories are rebuilt
+- **WHEN** post-restore reconciliation successfully re-upserts a subset of restored memories and a later memory in the same run fails
+- **THEN** successfully rebuilt memories remain marked as synced
+- **AND** only the remaining unreconciled memories stay pending vector recovery
+- **AND** a subsequent reconciliation run resumes from the remaining unsynced set

--- a/openspec/changes/harden-post-restore-reconciliation/tasks.md
+++ b/openspec/changes/harden-post-restore-reconciliation/tasks.md
@@ -1,0 +1,14 @@
+## 1. Restore control flow hardening
+
+- [ ] 1.1 Refactor `BackupService.restore` so restore lifecycle acquisition and in-progress cleanup are fail-safe across lock-acquisition and early-failure paths.
+- [ ] 1.2 Update restore semantics so once SQLite activation succeeds, later vector clear or reconciliation failures return explicit degraded readiness instead of full restore failure.
+
+## 2. Reconciliation durability
+
+- [ ] 2.1 Persist successful post-restore reconciliation progress incrementally so completed vector rebuild work survives a later failure in the same run.
+- [ ] 2.2 Ensure reconciliation retries and health/reporting surfaces continue from the remaining unsynced set after partial failure.
+
+## 3. Validation
+
+- [ ] 3.1 Add regression tests for post-activation vector-clear failure handling, partial reconciliation durability, and restore guard cleanup.
+- [ ] 3.2 Run `npm run lint`, `npm test`, and `npm run build` to verify the hardened restore behavior end to end.

--- a/openspec/changes/harden-post-restore-reconciliation/tasks.md
+++ b/openspec/changes/harden-post-restore-reconciliation/tasks.md
@@ -1,14 +1,14 @@
 ## 1. Restore control flow hardening
 
-- [ ] 1.1 Refactor `BackupService.restore` so restore lifecycle acquisition and in-progress cleanup are fail-safe across lock-acquisition and early-failure paths.
-- [ ] 1.2 Update restore semantics so once SQLite activation succeeds, later vector clear or reconciliation failures return explicit degraded readiness instead of full restore failure.
+- [x] 1.1 Refactor `BackupService.restore` so restore lifecycle acquisition and in-progress cleanup are fail-safe across lock-acquisition and early-failure paths.
+- [x] 1.2 Update restore semantics so once SQLite activation succeeds, later vector clear or reconciliation failures return explicit degraded readiness instead of full restore failure.
 
 ## 2. Reconciliation durability
 
-- [ ] 2.1 Persist successful post-restore reconciliation progress incrementally so completed vector rebuild work survives a later failure in the same run.
-- [ ] 2.2 Ensure reconciliation retries and health/reporting surfaces continue from the remaining unsynced set after partial failure.
+- [x] 2.1 Persist successful post-restore reconciliation progress incrementally so completed vector rebuild work survives a later failure in the same run.
+- [x] 2.2 Ensure reconciliation retries and health/reporting surfaces continue from the remaining unsynced set after partial failure.
 
 ## 3. Validation
 
-- [ ] 3.1 Add regression tests for post-activation vector-clear failure handling, partial reconciliation durability, and restore guard cleanup.
-- [ ] 3.2 Run `npm run lint`, `npm test`, and `npm run build` to verify the hardened restore behavior end to end.
+- [x] 3.1 Add regression tests for post-activation vector-clear failure handling, partial reconciliation durability, and restore guard cleanup.
+- [x] 3.2 Run `npm run lint`, `npm test`, and `npm run build` to verify the hardened restore behavior end to end.

--- a/openspec/changes/preserve-non-sliding-expiry/.openspec.yaml
+++ b/openspec/changes/preserve-non-sliding-expiry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-21

--- a/openspec/changes/preserve-non-sliding-expiry/design.md
+++ b/openspec/changes/preserve-non-sliding-expiry/design.md
@@ -1,0 +1,47 @@
+## Context
+
+The lifecycle service currently uses `null` to mean both “this tier has no expiry” and “do not extend expiry because sliding windows are disabled.” The search access-update path then writes that `null` back to storage, which can clear an existing `expires_at` value for T2/T3 memories. This is a small code change but an important lifecycle contract correction because it changes retention outcomes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Preserve existing expiry values when access tracking runs with sliding-window extension disabled.
+- Keep access-count and last-accessed updates working regardless of sliding-window policy.
+- Continue to support explicit expiry recalculation when tier changes or policy intentionally removes expiry.
+
+**Non-Goals:**
+- Changing promotion thresholds or the overall retention tier model.
+- Reworking unrelated search ranking or hydration logic.
+- Introducing new retention configuration flags.
+
+## Decisions
+
+1. Distinguish “preserve existing expiry” from “clear expiry.”
+- Decision: lifecycle and storage update contracts will use a no-change state distinct from explicit `null`.
+- Rationale: current `null` overloading is the direct source of the bug.
+- Alternative considered: special-case the bug only in `SearchService`. Rejected because the ambiguous contract would remain easy to misuse elsewhere.
+
+2. Non-sliding access updates preserve expiry unless policy actually changes the tier outcome.
+- Decision: when `sliding_window_enabled` is `false` and a memory remains in the same tier, access tracking updates counters and timestamps without modifying `expires_at`.
+- Rationale: disabling sliding windows means do not extend the deadline on access, not remove the deadline entirely.
+- Alternative considered: freeze all lifecycle fields, including promotion effects. Rejected because access-driven promotion can legitimately change lifecycle policy.
+
+3. Tier promotion may still recalculate expiry under non-sliding mode.
+- Decision: if an access update promotes a memory into a new tier, expiry is recomputed for the promoted tier even when sliding-window extension is otherwise disabled.
+- Rationale: promotion is a policy state change, not a sliding extension of the previous tier's TTL.
+- Alternative considered: preserve the prior expiry even on promotion. Rejected because it would make the promoted tier metadata internally inconsistent.
+
+## Risks / Trade-offs
+
+- [Tri-state expiry update semantics add a little complexity to storage helpers] -> Mitigation: keep the contract explicit and cover it with targeted tests.
+- [Promotion behavior under non-sliding mode may surprise operators if undocumented] -> Mitigation: make the requirement explicit in specs and tests.
+
+## Migration Plan
+
+1. Update lifecycle helpers to return an explicit no-change state for expiry when sliding windows are disabled and tier is unchanged.
+2. Update access-update assembly and SQLite write helpers to preserve expiry on no-change inputs.
+3. Add regression tests for unchanged-tier access and promotion-driven access under non-sliding mode.
+
+## Open Questions
+
+- Should the implementation represent “no expiry change” with `undefined`, or should it introduce a more explicit tagged value to make misuse impossible at compile time?

--- a/openspec/changes/preserve-non-sliding-expiry/proposal.md
+++ b/openspec/changes/preserve-non-sliding-expiry/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+When sliding-window expiry is disabled, read-path access updates currently appear to clear `expires_at` instead of preserving the existing deadline. That turns a configuration intended to disable expiry extension into behavior that can accidentally make time-bounded memories non-expiring.
+
+## What Changes
+
+- Define non-sliding expiry behavior so access tracking can update counters and timestamps without removing existing expiry values.
+- Separate “do not change expiry” from “explicitly clear expiry” in lifecycle and storage update contracts.
+- Add regression tests for search/read paths when `sliding_window_enabled` is `false`.
+
+## Capabilities
+
+### New Capabilities
+- `non-sliding-expiry-preservation`: preserves existing expiry metadata during access updates when sliding-window extension is disabled.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected code: `src/domain/lifecycle.ts`, `src/search/index.ts`, `src/storage/sqlite.ts`, and lifecycle/search tests.
+- Data behavior: prevents read access from silently removing TTLs under a non-sliding retention policy.
+- Reliability: makes retention configuration semantics safe and predictable for operators.

--- a/openspec/changes/preserve-non-sliding-expiry/specs/non-sliding-expiry-preservation/spec.md
+++ b/openspec/changes/preserve-non-sliding-expiry/specs/non-sliding-expiry-preservation/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Non-sliding access updates preserve existing expiry
+When sliding-window expiry is disabled and an access update does not change the memory's tier, the system SHALL preserve the existing `expires_at` value.
+
+#### Scenario: Access tracking preserves expiry for an unchanged tier
+- **WHEN** a T2 or T3 memory has an existing expiry timestamp
+- **AND** `sliding_window_enabled` is `false`
+- **AND** an access update records a new access count without promoting the memory
+- **THEN** the system updates access metadata
+- **AND** the stored expiry timestamp remains unchanged
+
+### Requirement: Expiry-clearing semantics are explicit
+The lifecycle and storage update contracts SHALL distinguish “do not change expiry” from “clear expiry” so access paths cannot remove TTLs implicitly.
+
+#### Scenario: No-change expiry input does not clear stored TTL
+- **WHEN** the read path submits an access update that indicates expiry should remain unchanged
+- **THEN** the storage layer preserves the existing `expires_at` value
+- **AND** it does not interpret the update as an instruction to write `null`
+
+### Requirement: Promotion still applies tier lifecycle policy under non-sliding mode
+When an access update promotes a memory into a new tier, the system SHALL recompute expiry for the promoted tier even if sliding-window extension is disabled.
+
+#### Scenario: Promotion recalculates expiry under non-sliding mode
+- **WHEN** `sliding_window_enabled` is `false`
+- **AND** a memory crosses the promotion threshold during an access update
+- **THEN** the system updates the retained tier
+- **AND** it applies the promoted tier's lifecycle metadata, including recomputed expiry when that tier has one

--- a/openspec/changes/preserve-non-sliding-expiry/tasks.md
+++ b/openspec/changes/preserve-non-sliding-expiry/tasks.md
@@ -1,0 +1,13 @@
+## 1. Expiry update contract
+
+- [ ] 1.1 Update lifecycle and access-update types so “preserve expiry” is represented separately from “clear expiry”.
+- [ ] 1.2 Update read-path access update assembly so unchanged-tier reads preserve the existing expiry while promotion still applies the promoted tier lifecycle policy.
+
+## 2. Storage and regression coverage
+
+- [ ] 2.1 Update SQLite access update helpers to honor no-change expiry inputs without writing `null`.
+- [ ] 2.2 Add regression tests for unchanged-tier access and promotion behavior when `sliding_window_enabled` is `false`.
+
+## 3. Validation
+
+- [ ] 3.1 Run `npm run lint`, `npm test`, and `npm run build` to verify the retention fix does not regress search or lifecycle behavior.

--- a/openspec/changes/restore-dual-store-backup-consistency/.openspec.yaml
+++ b/openspec/changes/restore-dual-store-backup-consistency/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-21

--- a/openspec/changes/restore-dual-store-backup-consistency/design.md
+++ b/openspec/changes/restore-dual-store-backup-consistency/design.md
@@ -1,0 +1,55 @@
+## Context
+
+BHGBrain treats SQLite as the system of record and Qdrant as the vector search index, but restore currently only replaces and reactivates SQLite. That means the running process can have restored metadata while Qdrant still reflects a newer or unrelated state. Because semantic search and similarity dedup depend on Qdrant, restore needs a clear dual-store story instead of assuming vector state is implicitly valid.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make restore semantics explicit for both SQLite metadata and Qdrant vector state.
+- Preserve SQLite-first recovery while preventing silent post-restore vector drift.
+- Surface restore readiness and post-restore reconciliation state to operators and health checks.
+- Define a path that works even if the backup artifact itself remains SQLite-only.
+
+**Non-Goals:**
+- Introducing a new external backup dependency or bundling vendor-specific Qdrant snapshot formats into this change.
+- Redesigning normal write-path synchronization rules outside restore and reconciliation flows.
+- Guaranteeing instant semantic readiness for very large restores.
+
+## Decisions
+
+1. Keep SQLite as the restore source of truth.
+- Decision: restore will continue to activate restored SQLite state first, and post-restore vector state will be derived from that restored metadata set.
+- Rationale: SQLite already owns durable metadata, auditability, and restore activation semantics in this codebase.
+- Alternative considered: make restore depend on a bundled Qdrant snapshot. Rejected because it would tightly couple backups to backend-specific artifacts and deployment details.
+
+2. Treat restore as a reconciliation boundary for vectors.
+- Decision: after restore, the system SHALL explicitly mark vector readiness as reconciled, reconciling, or pending instead of assuming Qdrant is valid.
+- Rationale: it prevents false-success restores where semantic features quietly operate on drifted data.
+- Alternative considered: leave existing vector state untouched and rely on health warnings only. Rejected because it still leaves semantic behavior undefined.
+
+3. Rebuild or re-sync vectors from restored SQLite content.
+- Decision: the design target is a reconciliation flow that re-upserts vectors from restored SQLite rows and updates sync markers as it completes.
+- Rationale: it keeps one authoritative recovery source and reuses existing embedding + Qdrant write primitives.
+- Alternative considered: clear all vectors and require manual external rebuild tooling. Rejected because it adds operator burden without a defined product contract.
+
+4. Restore success must distinguish metadata activation from semantic readiness.
+- Decision: restore responses and health reporting will separate “SQLite activated” from “vector state fully ready.”
+- Rationale: operators need to know whether the service is merely restored or fully ready for semantic features.
+- Alternative considered: one boolean success flag. Rejected because it hides the exact state that needs operator attention.
+
+## Risks / Trade-offs
+
+- [Vector reconciliation can be expensive for large restores] -> Mitigation: allow batched reconciliation and explicit degraded health while batches run.
+- [Reconciliation depends on embedding availability] -> Mitigation: preserve restored SQLite state even when embeddings are unavailable and report pending vector recovery explicitly.
+- [Temporary degraded semantic behavior after restore can surprise clients] -> Mitigation: expose readiness in restore responses and health snapshots so the degraded window is explicit and testable.
+
+## Migration Plan
+
+1. Extend restore workflow to mark or compute post-restore vector reconciliation state.
+2. Add reconciliation helpers that can rebuild vectors from restored SQLite rows.
+3. Update restore response and health reporting to surface metadata activation and vector readiness separately.
+4. Add tests for restore with stale Qdrant state, missing embeddings, and successful reconciliation.
+
+## Open Questions
+
+- Should reconciliation run inline for small restores and switch to batched/background execution only past a size threshold, or should all restores use the same asynchronous readiness contract?

--- a/openspec/changes/restore-dual-store-backup-consistency/proposal.md
+++ b/openspec/changes/restore-dual-store-backup-consistency/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Backup restore now reactivates SQLite correctly in-process, but the system is still a dual-store design and restore only persists SQLite bytes. That leaves restored metadata and Qdrant vector state free to drift apart, which can break semantic search, similarity dedup, and health expectations after restore.
+
+## What Changes
+
+- Define backup and restore as a dual-store consistency workflow instead of a SQLite-only workflow.
+- Require restore to either recover vector state alongside SQLite or enter an explicit reconciliation mode that rebuilds or marks vector state before normal semantic features resume.
+- Define operator-visible restore results and health signals for post-restore vector consistency.
+- Add integrity and regression coverage for restore scenarios where SQLite state is older than Qdrant state.
+
+## Capabilities
+
+### New Capabilities
+- `dual-store-backup-restore-consistency`: ensures backup and restore preserve or explicitly reconcile both SQLite metadata and Qdrant vector state.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected code: `src/backup/index.ts`, `src/storage/index.ts`, `src/storage/qdrant.ts`, `src/storage/sqlite.ts`, `src/health`, and related restore tests.
+- API behavior: restore responses and health reporting become explicit about vector recovery state.
+- Reliability: prevents false-success restores that leave semantic search and dedup operating on stale or missing vectors.

--- a/openspec/changes/restore-dual-store-backup-consistency/specs/dual-store-backup-restore-consistency/spec.md
+++ b/openspec/changes/restore-dual-store-backup-consistency/specs/dual-store-backup-restore-consistency/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Restore SHALL make vector consistency explicit
+When a restore activates SQLite state, the system SHALL also report whether Qdrant vector state is already reconciled, actively reconciling, or still pending reconciliation.
+
+#### Scenario: Restore response distinguishes activation from reconciliation
+- **WHEN** a restore operation successfully activates restored SQLite bytes in the running process
+- **THEN** the restore result reports metadata activation success
+- **AND** the result also reports the post-restore vector consistency state instead of implying semantic readiness automatically
+
+### Requirement: Restored metadata SHALL not silently trust pre-existing vector state
+After restore, the system SHALL not assume that previously existing Qdrant vectors match the restored SQLite dataset unless reconciliation has explicitly confirmed or rebuilt that state.
+
+#### Scenario: Older SQLite restore invalidates newer vector assumptions
+- **WHEN** an operator restores SQLite data from an earlier backup while Qdrant still contains vectors from a newer state
+- **THEN** the system marks vector consistency as unreconciled
+- **AND** semantic health does not report the service as fully ready until reconciliation completes
+
+### Requirement: Restore reconciliation SHALL rebuild vectors from restored SQLite content
+The system SHALL provide a reconciliation path that re-upserts vectors from restored SQLite rows and updates sync state as each restored memory is brought back into semantic readiness.
+
+#### Scenario: Reconciliation rebuilds vectors after restore
+- **WHEN** restore finishes with unreconciled vector state and embeddings are available
+- **THEN** the reconciliation flow reads restored memories from SQLite
+- **AND** it upserts vectors into the correct Qdrant collections
+- **AND** it updates each memory's vector sync state as reconciliation succeeds
+
+#### Scenario: Restore remains explicitly degraded when embeddings are unavailable
+- **WHEN** restore finishes but the embedding provider is unavailable for reconciliation
+- **THEN** restored SQLite data remains active
+- **AND** semantic readiness remains in a degraded or pending state
+- **AND** health reporting indicates that vector reconciliation is still required

--- a/openspec/changes/restore-dual-store-backup-consistency/tasks.md
+++ b/openspec/changes/restore-dual-store-backup-consistency/tasks.md
@@ -1,0 +1,14 @@
+## 1. Restore consistency model
+
+- [x] 1.1 Extend restore and health contracts to represent metadata activation separately from vector reconciliation state.
+- [x] 1.2 Add storage and reconciliation helpers that can mark restored memories unsynced and iterate restored SQLite rows for vector rebuild.
+
+## 2. Dual-store restore implementation
+
+- [x] 2.1 Update restore flow so activating restored SQLite state does not silently trust pre-existing Qdrant vectors.
+- [x] 2.2 Implement post-restore vector reconciliation that re-upserts restored memories into the correct Qdrant collections and preserves explicit degraded behavior when embeddings are unavailable.
+
+## 3. Validation
+
+- [x] 3.1 Add regression tests for restore with stale vector state, successful reconciliation, and pending/degraded behavior when embeddings are unavailable.
+- [x] 3.2 Run `npm run lint`, `npm test`, and `npm run build` to verify restore readiness and health semantics.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,15 @@
         "bhgbrain-server": "dist/index.js"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/express": "^5.0.1",
         "@types/node": "^22.13.10",
         "@types/uuid": "^10.0.0",
         "@vitest/coverage-v8": "^3.2.4",
+        "eslint": "^10.0.3",
         "tsx": "^4.19.3",
         "typescript": "^5.8.2",
+        "typescript-eslint": "^8.57.1",
         "vitest": "^3.0.8"
       },
       "engines": {
@@ -552,6 +555,134 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.11",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
@@ -562,6 +693,58 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1104,6 +1287,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1140,6 +1330,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1203,6 +1400,236 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
+      "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/type-utils": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.57.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
+      "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
+      "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.57.1",
+        "@typescript-eslint/types": "^8.57.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
+      "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
+      "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
+      "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
+      "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
+      "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.57.1",
+        "@typescript-eslint/tsconfig-utils": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
+      "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
+      "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",
@@ -1376,6 +1803,29 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/agentkeepalive": {
@@ -1754,6 +2204,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1915,6 +2372,185 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
+      "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.1.1",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1923,6 +2559,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -2041,6 +2687,20 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -2075,6 +2735,19 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2095,6 +2768,44 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -2283,6 +2994,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2438,6 +3162,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2462,6 +3206,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2470,6 +3224,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-promise": {
@@ -2570,6 +3337,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -2581,6 +3355,53 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -2740,6 +3561,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -2885,6 +3713,56 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -2899,6 +3777,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -3049,6 +3937,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -3076,6 +3974,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -3691,6 +4599,19 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -3709,6 +4630,19 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-is": {
@@ -3738,6 +4672,30 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.1.tgz",
+      "integrity": "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.57.1",
+        "@typescript-eslint/parser": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
     "node_modules/undici": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
@@ -3760,6 +4718,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/uuid": {
@@ -4012,6 +4980,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -4115,6 +5093,19 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,12 +27,87 @@
         "@types/express": "^5.0.1",
         "@types/node": "^22.13.10",
         "@types/uuid": "^10.0.0",
+        "@vitest/coverage-v8": "^3.2.4",
         "tsx": "^4.19.3",
         "typescript": "^5.8.2",
         "vitest": "^3.0.8"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -489,12 +564,72 @@
         "hono": "^4"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
@@ -541,6 +676,17 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@qdrant/js-client-rest": {
       "version": "1.17.0",
@@ -1058,6 +1204,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1243,6 +1423,32 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1252,6 +1458,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1266,6 +1491,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/body-parser": {
@@ -1290,6 +1525,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -1366,6 +1614,26 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1518,10 +1786,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1814,6 +2096,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -1962,6 +2261,61 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1972,6 +2326,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -2021,6 +2385,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -2091,6 +2462,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -2102,6 +2483,76 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jose": {
       "version": "6.2.0",
@@ -2138,6 +2589,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2146,6 +2604,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2201,6 +2687,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -2373,6 +2885,13 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2389,6 +2908,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2691,6 +3227,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -2842,6 +3391,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -2899,6 +3461,110 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -2910,6 +3576,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/thread-stream": {
@@ -3313,6 +4007,104 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "tsc --noEmit"
+    "lint": "npm run lint:types && npm run lint:eslint",
+    "lint:types": "tsc --noEmit",
+    "lint:eslint": "eslint src"
   },
   "keywords": [
     "mcp",
@@ -39,12 +41,15 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/express": "^5.0.1",
     "@types/node": "^22.13.10",
     "@types/uuid": "^10.0.0",
     "@vitest/coverage-v8": "^3.2.4",
+    "eslint": "^10.0.3",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2",
+    "typescript-eslint": "^8.57.1",
     "vitest": "^3.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,13 @@
     "test:watch": "vitest",
     "lint": "tsc --noEmit"
   },
-  "keywords": ["mcp", "memory", "brain", "vector", "qdrant"],
+  "keywords": [
+    "mcp",
+    "memory",
+    "brain",
+    "vector",
+    "qdrant"
+  ],
   "license": "MIT",
   "engines": {
     "node": ">=20.0.0"
@@ -36,6 +42,7 @@
     "@types/express": "^5.0.1",
     "@types/node": "^22.13.10",
     "@types/uuid": "^10.0.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2",
     "vitest": "^3.0.8"

--- a/src/backup/index.test.ts
+++ b/src/backup/index.test.ts
@@ -4,6 +4,9 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { BackupService } from './index.js';
+import type { BrainConfig } from '../config/index.js';
+import type pino from 'pino';
+import type { StorageManager } from '../storage/index.js';
 
 function makeBackupFile(dir: string, payload: Buffer): string {
   const checksum = createHash('sha256').update(payload).digest('hex');
@@ -30,10 +33,11 @@ describe('BackupService restore activation', () => {
         countMemories: vi.fn(() => 7),
       },
       reloadSqliteFromDisk: vi.fn(async () => {}),
-    } as any;
+    } as unknown as StorageManager;
 
-    const logger = { info: vi.fn(), error: vi.fn() } as any;
-    const service = new BackupService({ data_dir: tempDir } as any, storage, logger);
+    const logger = { info: vi.fn(), error: vi.fn() } as unknown as pino.Logger;
+    const config = { data_dir: tempDir } as unknown as BrainConfig;
+    const service = new BackupService(config, storage, logger);
 
     const result = await service.restore(backupPath);
     expect(result).toEqual({ memory_count: 7, activated: true });
@@ -57,10 +61,11 @@ describe('BackupService restore activation', () => {
         countMemories: vi.fn(() => 0),
       },
       reloadSqliteFromDisk: vi.fn(async () => { throw new Error('reload exploded'); }),
-    } as any;
+    } as unknown as StorageManager;
 
-    const logger = { info: vi.fn(), error: vi.fn() } as any;
-    const service = new BackupService({ data_dir: tempDir } as any, storage, logger);
+    const logger = { info: vi.fn(), error: vi.fn() } as unknown as pino.Logger;
+    const config = { data_dir: tempDir } as unknown as BrainConfig;
+    const service = new BackupService(config, storage, logger);
 
     await expect(service.restore(backupPath)).rejects.toThrow('activation failed');
     expect(logger.error).toHaveBeenCalled();
@@ -85,9 +90,10 @@ describe('BackupService restore activation', () => {
       reloadSqliteFromDisk: vi.fn(() => new Promise<void>((resolve) => {
         resolveReload = resolve;
       })),
-    } as any;
+    } as unknown as StorageManager;
 
-    const service = new BackupService({ data_dir: tempDir } as any, storage);
+    const config = { data_dir: tempDir } as unknown as BrainConfig;
+    const service = new BackupService(config, storage);
 
     const first = service.restore(backupPath);
     const second = service.restore(backupPath);

--- a/src/backup/index.test.ts
+++ b/src/backup/index.test.ts
@@ -7,6 +7,7 @@ import { BackupService } from './index.js';
 import type { BrainConfig } from '../config/index.js';
 import type pino from 'pino';
 import type { StorageManager } from '../storage/index.js';
+import { embeddingUnavailable } from '../errors/index.js';
 
 function makeBackupFile(dir: string, payload: Buffer): string {
   const checksum = createHash('sha256').update(payload).digest('hex');
@@ -31,8 +32,12 @@ describe('BackupService restore activation', () => {
         endLifecycleOperation: vi.fn(),
         getDatabasePath: vi.fn(() => join(tempDir, 'brain.db')),
         countMemories: vi.fn(() => 7),
+        countUnsyncedVectors: vi.fn(() => 0),
       },
       reloadSqliteFromDisk: vi.fn(async () => {}),
+      markAllMemoriesVectorSync: vi.fn(() => 7),
+      clearManagedVectors: vi.fn(async () => 2),
+      reconcileVectorsFromSqlite: vi.fn(async () => ({ reconciled: 7, remaining: 0 })),
     } as unknown as StorageManager;
 
     const logger = { info: vi.fn(), error: vi.fn() } as unknown as pino.Logger;
@@ -40,10 +45,63 @@ describe('BackupService restore activation', () => {
     const service = new BackupService(config, storage, logger);
 
     const result = await service.restore(backupPath);
-    expect(result).toEqual({ memory_count: 7, activated: true });
+    expect(result).toEqual({
+      memory_count: 7,
+      metadata_activated: true,
+      vector_reconciliation: {
+        status: 'healthy',
+        state: 'reconciled',
+        unsynced_vectors: 0,
+      },
+    });
     expect(storage.sqlite.beginLifecycleOperation).toHaveBeenCalledWith('restore');
     expect(storage.sqlite.endLifecycleOperation).toHaveBeenCalledWith('restore');
     expect(storage.reloadSqliteFromDisk).toHaveBeenCalledTimes(1);
+    expect(storage.markAllMemoriesVectorSync).toHaveBeenCalledWith(false, { allowDuringLifecycle: true });
+    expect(storage.clearManagedVectors).toHaveBeenCalledTimes(1);
+    expect(storage.reconcileVectorsFromSqlite).toHaveBeenCalledWith({ batchSize: 100, allowDuringLifecycle: true });
+
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('reports pending vector reconciliation when embeddings are unavailable after activation', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'bhgbrain-backup-test-'));
+    const payload = Buffer.from('db-bytes-pending');
+    const backupPath = makeBackupFile(tempDir, payload);
+
+    const storage = {
+      sqlite: {
+        beginLifecycleOperation: vi.fn(),
+        endLifecycleOperation: vi.fn(),
+        getDatabasePath: vi.fn(() => join(tempDir, 'brain.db')),
+        countMemories: vi.fn(() => 4),
+        countUnsyncedVectors: vi.fn(() => 4),
+      },
+      reloadSqliteFromDisk: vi.fn(async () => {}),
+      markAllMemoriesVectorSync: vi.fn(() => 4),
+      clearManagedVectors: vi.fn(async () => 1),
+      reconcileVectorsFromSqlite: vi.fn(async () => {
+        throw embeddingUnavailable('Embedding provider is unavailable: missing API credentials');
+      }),
+    } as unknown as StorageManager;
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as pino.Logger;
+    const config = { data_dir: tempDir } as unknown as BrainConfig;
+    const service = new BackupService(config, storage, logger);
+
+    const result = await service.restore(backupPath);
+
+    expect(result).toEqual({
+      memory_count: 4,
+      metadata_activated: true,
+      vector_reconciliation: {
+        status: 'degraded',
+        state: 'pending',
+        unsynced_vectors: 4,
+        message: 'Embedding provider is unavailable: missing API credentials',
+      },
+    });
+    expect(logger.warn).toHaveBeenCalled();
 
     rmSync(tempDir, { recursive: true, force: true });
   });
@@ -59,8 +117,12 @@ describe('BackupService restore activation', () => {
         endLifecycleOperation: vi.fn(),
         getDatabasePath: vi.fn(() => join(tempDir, 'brain.db')),
         countMemories: vi.fn(() => 0),
+        countUnsyncedVectors: vi.fn(() => 0),
       },
       reloadSqliteFromDisk: vi.fn(async () => { throw new Error('reload exploded'); }),
+      markAllMemoriesVectorSync: vi.fn(),
+      clearManagedVectors: vi.fn(),
+      reconcileVectorsFromSqlite: vi.fn(),
     } as unknown as StorageManager;
 
     const logger = { info: vi.fn(), error: vi.fn() } as unknown as pino.Logger;
@@ -86,10 +148,14 @@ describe('BackupService restore activation', () => {
         endLifecycleOperation: vi.fn(),
         getDatabasePath: vi.fn(() => join(tempDir, 'brain.db')),
         countMemories: vi.fn(() => 1),
+        countUnsyncedVectors: vi.fn(() => 0),
       },
       reloadSqliteFromDisk: vi.fn(() => new Promise<void>((resolve) => {
         resolveReload = resolve;
       })),
+      markAllMemoriesVectorSync: vi.fn(() => 1),
+      clearManagedVectors: vi.fn(async () => 1),
+      reconcileVectorsFromSqlite: vi.fn(async () => ({ reconciled: 1, remaining: 0 })),
     } as unknown as StorageManager;
 
     const config = { data_dir: tempDir } as unknown as BrainConfig;

--- a/src/backup/index.test.ts
+++ b/src/backup/index.test.ts
@@ -106,6 +106,47 @@ describe('BackupService restore activation', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
+  it('reports pending vector reconciliation when managed vector clearing fails after activation', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'bhgbrain-backup-test-'));
+    const payload = Buffer.from('db-bytes-clear-fail');
+    const backupPath = makeBackupFile(tempDir, payload);
+
+    const storage = {
+      sqlite: {
+        beginLifecycleOperation: vi.fn(),
+        endLifecycleOperation: vi.fn(),
+        getDatabasePath: vi.fn(() => join(tempDir, 'brain.db')),
+        countMemories: vi.fn(() => 3),
+        countUnsyncedVectors: vi.fn(() => 3),
+      },
+      reloadSqliteFromDisk: vi.fn(async () => {}),
+      markAllMemoriesVectorSync: vi.fn(() => 3),
+      clearManagedVectors: vi.fn(async () => { throw new Error('qdrant clear exploded'); }),
+      reconcileVectorsFromSqlite: vi.fn(async () => ({ reconciled: 3, remaining: 0 })),
+    } as unknown as StorageManager;
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as pino.Logger;
+    const config = { data_dir: tempDir } as unknown as BrainConfig;
+    const service = new BackupService(config, storage, logger);
+
+    const result = await service.restore(backupPath);
+
+    expect(result).toEqual({
+      memory_count: 3,
+      metadata_activated: true,
+      vector_reconciliation: {
+        status: 'degraded',
+        state: 'pending',
+        unsynced_vectors: 3,
+        message: 'qdrant clear exploded',
+      },
+    });
+    expect(storage.reconcileVectorsFromSqlite).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
+
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
   it('fails restore when activation fails', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'bhgbrain-backup-test-'));
     const payload = Buffer.from('db-bytes-2');
@@ -132,6 +173,51 @@ describe('BackupService restore activation', () => {
     await expect(service.restore(backupPath)).rejects.toThrow('activation failed');
     expect(logger.error).toHaveBeenCalled();
     expect(storage.sqlite.endLifecycleOperation).toHaveBeenCalledWith('restore');
+
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('cleans up restore guard state when guard acquisition fails before activation', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'bhgbrain-backup-test-'));
+    const payload = Buffer.from('db-bytes-guard-fail');
+    const backupPath = makeBackupFile(tempDir, payload);
+
+    const beginLifecycleOperation = vi.fn()
+      .mockImplementationOnce(() => {
+        throw new Error('restore lock busy');
+      })
+      .mockImplementation(() => {});
+
+    const storage = {
+      sqlite: {
+        beginLifecycleOperation,
+        endLifecycleOperation: vi.fn(),
+        getDatabasePath: vi.fn(() => join(tempDir, 'brain.db')),
+        countMemories: vi.fn(() => 2),
+        countUnsyncedVectors: vi.fn(() => 0),
+      },
+      reloadSqliteFromDisk: vi.fn(async () => {}),
+      markAllMemoriesVectorSync: vi.fn(() => 2),
+      clearManagedVectors: vi.fn(async () => 1),
+      reconcileVectorsFromSqlite: vi.fn(async () => ({ reconciled: 2, remaining: 0 })),
+    } as unknown as StorageManager;
+
+    const config = { data_dir: tempDir } as unknown as BrainConfig;
+    const service = new BackupService(config, storage);
+
+    await expect(service.restore(backupPath)).rejects.toThrow('already in progress');
+
+    const secondAttempt = await service.restore(backupPath);
+    expect(secondAttempt).toEqual({
+      memory_count: 2,
+      metadata_activated: true,
+      vector_reconciliation: {
+        status: 'healthy',
+        state: 'reconciled',
+        unsynced_vectors: 0,
+      },
+    });
+    expect(storage.sqlite.endLifecycleOperation).toHaveBeenCalledTimes(1);
 
     rmSync(tempDir, { recursive: true, force: true });
   });

--- a/src/backup/index.ts
+++ b/src/backup/index.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import type { BrainConfig } from '../config/index.js';
 import type { StorageManager } from '../storage/index.js';
 import { atomicWriteFileSync } from '../storage/sqlite.js';
-import type { BackupInfo } from '../domain/types.js';
+import type { BackupInfo, RestoreResult, VectorReconciliationStatus } from '../domain/types.js';
 import { BrainError, invalidInput, internal } from '../errors/index.js';
 import type pino from 'pino';
 
@@ -73,7 +73,7 @@ export class BackupService {
     }));
   }
 
-  async restore(backupPath: string): Promise<{ memory_count: number; activated: boolean }> {
+  async restore(backupPath: string): Promise<RestoreResult> {
     if (this.restoreInProgress) {
       throw invalidInput('Backup restore already in progress');
     }
@@ -120,20 +120,70 @@ export class BackupService {
       }
 
       const activeCount = this.storage.sqlite.countMemories();
+      this.storage.markAllMemoriesVectorSync(false, { allowDuringLifecycle: true });
+      await this.storage.clearManagedVectors();
+      const vectorReconciliation = await this.reconcileVectorsAfterRestore(activeCount);
       this.logger?.info({
         event: 'backup_restore_complete',
         path: backupPath,
-        activated: true,
+        metadata_activated: true,
         memory_count: activeCount,
+        vector_reconciliation_state: vectorReconciliation.state,
+        unsynced_vectors: vectorReconciliation.unsynced_vectors,
       });
 
-      return { memory_count: activeCount, activated: true };
+      return {
+        memory_count: activeCount,
+        metadata_activated: true,
+        vector_reconciliation: vectorReconciliation,
+      };
     } catch (err) {
       if (err instanceof BrainError) throw err;
       throw internal(`Backup restore failed: ${(err as Error).message}`);
     } finally {
       this.storage.sqlite.endLifecycleOperation('restore');
       this.restoreInProgress = false;
+    }
+  }
+
+  private async reconcileVectorsAfterRestore(memoryCount: number): Promise<VectorReconciliationStatus> {
+    if (memoryCount === 0) {
+      return {
+        status: 'healthy',
+        state: 'reconciled',
+        unsynced_vectors: 0,
+      };
+    }
+
+    try {
+      const result = await this.storage.reconcileVectorsFromSqlite({ batchSize: 100, allowDuringLifecycle: true });
+      if (result.remaining > 0) {
+        return {
+          status: 'degraded',
+          state: 'pending',
+          unsynced_vectors: result.remaining,
+          message: 'Restore activated SQLite metadata, but vector reconciliation is still pending.',
+        };
+      }
+      return {
+        status: 'healthy',
+        state: 'reconciled',
+        unsynced_vectors: 0,
+      };
+    } catch (err) {
+      const message = err instanceof Error
+        ? err.message
+        : 'Restore activated SQLite metadata, but vector reconciliation is still pending.';
+      this.logger?.warn?.({
+        event: 'backup_restore_vector_reconciliation_pending',
+        error: message,
+      });
+      return {
+        status: 'degraded',
+        state: 'pending',
+        unsynced_vectors: this.storage.sqlite.countUnsyncedVectors(),
+        message,
+      };
     }
   }
 }

--- a/src/backup/index.ts
+++ b/src/backup/index.ts
@@ -74,17 +74,14 @@ export class BackupService {
   }
 
   async restore(backupPath: string): Promise<RestoreResult> {
-    if (this.restoreInProgress) {
-      throw invalidInput('Backup restore already in progress');
-    }
-
     if (!existsSync(backupPath)) {
       throw invalidInput(`Backup file not found: ${backupPath}`);
     }
 
-    this.restoreInProgress = true;
-    this.storage.sqlite.beginLifecycleOperation('restore');
+    let restoreGuardAcquired = false;
     try {
+      this.beginRestoreOperation();
+      restoreGuardAcquired = true;
       this.logger?.info({ event: 'backup_restore_validate', path: backupPath });
       const data = readFileSync(backupPath);
       const headerLen = data.readUInt32LE(0);
@@ -120,9 +117,7 @@ export class BackupService {
       }
 
       const activeCount = this.storage.sqlite.countMemories();
-      this.storage.markAllMemoriesVectorSync(false, { allowDuringLifecycle: true });
-      await this.storage.clearManagedVectors();
-      const vectorReconciliation = await this.reconcileVectorsAfterRestore(activeCount);
+      const vectorReconciliation = await this.restoreVectorStateAfterActivation(activeCount);
       this.logger?.info({
         event: 'backup_restore_complete',
         path: backupPath,
@@ -141,9 +136,44 @@ export class BackupService {
       if (err instanceof BrainError) throw err;
       throw internal(`Backup restore failed: ${(err as Error).message}`);
     } finally {
-      this.storage.sqlite.endLifecycleOperation('restore');
-      this.restoreInProgress = false;
+      if (restoreGuardAcquired) {
+        try {
+          this.storage.sqlite.endLifecycleOperation('restore');
+        } finally {
+          this.restoreInProgress = false;
+        }
+      }
     }
+  }
+
+  private beginRestoreOperation(): void {
+    if (this.restoreInProgress) {
+      throw invalidInput('Backup restore already in progress');
+    }
+
+    try {
+      this.storage.sqlite.beginLifecycleOperation('restore');
+    } catch {
+      throw invalidInput('Backup restore already in progress');
+    }
+
+    this.restoreInProgress = true;
+  }
+
+  private async restoreVectorStateAfterActivation(memoryCount: number): Promise<VectorReconciliationStatus> {
+    try {
+      this.storage.markAllMemoriesVectorSync(false, { allowDuringLifecycle: true });
+    } catch (err) {
+      return this.toPendingVectorReconciliation(err, 'backup_restore_vector_invalidation_pending');
+    }
+
+    try {
+      await this.storage.clearManagedVectors();
+    } catch (err) {
+      return this.toPendingVectorReconciliation(err, 'backup_restore_vector_clear_pending');
+    }
+
+    return this.reconcileVectorsAfterRestore(memoryCount);
   }
 
   private async reconcileVectorsAfterRestore(memoryCount: number): Promise<VectorReconciliationStatus> {
@@ -171,19 +201,26 @@ export class BackupService {
         unsynced_vectors: 0,
       };
     } catch (err) {
-      const message = err instanceof Error
-        ? err.message
-        : 'Restore activated SQLite metadata, but vector reconciliation is still pending.';
-      this.logger?.warn?.({
-        event: 'backup_restore_vector_reconciliation_pending',
-        error: message,
-      });
-      return {
-        status: 'degraded',
-        state: 'pending',
-        unsynced_vectors: this.storage.sqlite.countUnsyncedVectors(),
-        message,
-      };
+      return this.toPendingVectorReconciliation(err, 'backup_restore_vector_reconciliation_pending');
     }
+  }
+
+  private toPendingVectorReconciliation(
+    err: unknown,
+    event: string,
+  ): VectorReconciliationStatus {
+    const message = err instanceof Error
+      ? err.message
+      : 'Restore activated SQLite metadata, but vector reconciliation is still pending.';
+    this.logger?.warn?.({
+      event,
+      error: message,
+    });
+    return {
+      status: 'degraded',
+      state: 'pending',
+      unsynced_vectors: this.storage.sqlite.countUnsyncedVectors(),
+      message,
+    };
   }
 }

--- a/src/backup/retention.test.ts
+++ b/src/backup/retention.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from 'node:os';
 import { SqliteStore } from '../storage/sqlite.js';
 import { RetentionService } from './retention.js';
 import { vi } from 'vitest';
+import type { BrainConfig } from '../config/index.js';
+import type { StorageManager } from '../storage/index.js';
 
 describe('RetentionService', () => {
   let sqlite: SqliteStore;
@@ -49,7 +51,9 @@ describe('RetentionService', () => {
     sqlite.insertMemory(memory('cat-1', '2025-01-01T00:00:00.000Z', 'policy'));
     sqlite.flushIfDirty();
 
-    const retention = new RetentionService({ retention: { decay_after_days: 30 } } as any, { sqlite } as any);
+    const config = { retention: { decay_after_days: 30 } } as unknown as BrainConfig;
+    const storage = { sqlite } as unknown as StorageManager;
+    const retention = new RetentionService(config, storage);
     const staleMarked = retention.markStaleMemories();
 
     expect(staleMarked).toBe(1);
@@ -76,11 +80,12 @@ describe('RetentionService', () => {
       },
       deleteMemories: vi.fn(async () => 1),
       logAudit: vi.fn(),
-    } as any;
+    } as unknown as StorageManager;
 
-    const retention = new RetentionService({
+    const config = {
       retention: { archive_before_delete: true, pre_expiry_warning_days: 7 },
-    } as any, storage);
+    } as unknown as BrainConfig;
+    const retention = new RetentionService(config, storage);
 
     const result = await retention.runGc();
 

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ToolContext } from '../tools/index.js';
+
+const retentionMocks = {
+  runGc: vi.fn(),
+  getTierStats: vi.fn(),
+  listExpiringSoon: vi.fn(),
+  buildMetadataForTier: vi.fn(),
+  listArchive: vi.fn(),
+  searchArchive: vi.fn(),
+  restoreArchive: vi.fn(),
+};
+
+vi.mock('../config/index.js', () => ({
+  loadConfig: vi.fn(),
+  ensureDataDir: vi.fn(),
+}));
+
+vi.mock('../storage/sqlite.js', () => ({
+  SqliteStore: class {},
+}));
+
+vi.mock('../storage/qdrant.js', () => ({
+  QdrantStore: class {},
+}));
+
+vi.mock('../storage/index.js', () => ({
+  StorageManager: class {},
+}));
+
+vi.mock('../embedding/index.js', () => ({
+  createEmbeddingProvider: vi.fn(),
+}));
+
+vi.mock('../pipeline/index.js', () => ({
+  WritePipeline: class {},
+}));
+
+vi.mock('../search/index.js', () => ({
+  SearchService: class {},
+}));
+
+vi.mock('../backup/index.js', () => ({
+  BackupService: class {},
+}));
+
+vi.mock('../health/index.js', () => ({
+  HealthService: class {},
+}));
+
+vi.mock('../backup/retention.js', () => ({
+  RetentionService: class {
+    runGc = retentionMocks.runGc;
+    getTierStats = retentionMocks.getTierStats;
+    listExpiringSoon = retentionMocks.listExpiringSoon;
+    buildMetadataForTier = retentionMocks.buildMetadataForTier;
+    listArchive = retentionMocks.listArchive;
+    searchArchive = retentionMocks.searchArchive;
+    restoreArchive = retentionMocks.restoreArchive;
+  },
+}));
+
+vi.mock('../health/metrics.js', () => ({
+  MetricsCollector: class {},
+}));
+
+vi.mock('../health/logger.js', () => ({
+  createLogger: vi.fn(),
+}));
+
+vi.mock('../resilience/index.js', () => ({
+  CircuitBreaker: class {},
+}));
+
+vi.mock('../tools/index.js', () => ({
+  handleTool: vi.fn(async (_ctx, name) => ({ ok: true, tool: name })),
+}));
+
+describe('CLI', () => {
+  beforeEach(() => {
+    retentionMocks.runGc.mockReset().mockResolvedValue({ deleted: 2 });
+    retentionMocks.getTierStats.mockReset().mockReturnValue({
+      archived: 3,
+      unsynced_vectors: 1,
+      counts: { T0: 1, T1: 2, T2: 3, T3: 4 },
+    });
+    retentionMocks.listExpiringSoon.mockReset().mockReturnValue([{
+      id: '12345678-1234-1234-1234-123456789abc',
+      retention_tier: 'T2',
+      expires_at: '2026-04-01T00:00:00.000Z',
+      summary: 'Expiring soon',
+    }]);
+    retentionMocks.buildMetadataForTier.mockReset().mockReturnValue({
+      expires_at: '2026-04-01T00:00:00.000Z',
+      decay_eligible: true,
+      review_due: '2026-03-25T00:00:00.000Z',
+    });
+    retentionMocks.listArchive.mockReset().mockReturnValue([{ id: 'arch-1' }]);
+    retentionMocks.searchArchive.mockReset().mockReturnValue([{ id: 'arch-2' }]);
+    retentionMocks.restoreArchive.mockReset().mockResolvedValue({ restored: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    process.exitCode = undefined;
+  });
+
+  function createMockContext(): ToolContext {
+    return {
+      config: {
+        retention: { max_memories: 500000, tier_budgets: { T0: null, T1: 100000, T2: 200000, T3: 200000 } },
+      } as never,
+      storage: {
+        sqlite: {
+          listMemories: vi.fn(() => [{
+            id: '12345678-1234-1234-1234-123456789abc',
+            type: 'semantic',
+            summary: 'Remember this',
+            tags: ['tag1'],
+            importance: 0.7,
+            created_at: '2026-03-19T00:00:00.000Z',
+            retention_tier: 'T1',
+            expires_at: '2026-04-01T00:00:00.000Z',
+            decay_eligible: false,
+            review_due: '2026-03-25T00:00:00.000Z',
+          }]),
+          getMemoryById: vi.fn((id: string) => id === 'missing'
+            ? null
+            : {
+                id,
+                type: 'semantic',
+                summary: 'Memory',
+                tags: ['tag1'],
+                importance: 0.7,
+                created_at: '2026-03-19T00:00:00.000Z',
+                retention_tier: 'T1',
+                expires_at: '2026-04-01T00:00:00.000Z',
+                decay_eligible: false,
+                review_due: '2026-03-25T00:00:00.000Z',
+              }),
+          updateMemory: vi.fn(),
+          flushIfDirty: vi.fn(),
+          countMemories: vi.fn(() => 10),
+          listCollections: vi.fn(() => [{ name: 'general', count: 1 }]),
+          listCategories: vi.fn(() => [{ name: 'policy', slot: 'custom', revision: 2 }]),
+          getDbSizeBytes: vi.fn(() => 2048),
+          listAudit: vi.fn(() => [{
+            timestamp: '2026-03-19T00:00:00.000Z',
+            operation: 'remember',
+            memory_id: '12345678',
+            namespace: 'global',
+            client_id: 'cli',
+          }]),
+          close: vi.fn(),
+        },
+      } as never,
+      health: {
+        check: vi.fn(async () => ({ status: 'healthy' })),
+      } as never,
+      embedding: {} as never,
+      pipeline: {} as never,
+      search: {} as never,
+      backup: {} as never,
+      metrics: {} as never,
+      logger: {} as never,
+    };
+  }
+
+  async function runProgram(args: string[], context?: ToolContext) {
+    const { createProgram } = await import('./index.js');
+    const createContext = vi.fn(async () => context ?? createMockContext());
+    await createProgram(createContext as never).parseAsync(['node', 'bhgbrain', ...args]);
+    return { createContext };
+  }
+
+  it('exits with code 1 and logs a fatal error when config loading fails', async () => {
+    const { loadConfig } = await import('../config/index.js');
+    vi.mocked(loadConfig).mockImplementation(() => {
+      throw new Error('Invalid config: embedding.provider');
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { runCli } = await import('./index.js');
+    await runCli(['node', 'bhgbrain', 'list']);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith('Fatal error:', expect.any(Error));
+    expect(String(errorSpy.mock.calls[0]?.[1])).toContain('Invalid config: embedding.provider');
+  });
+
+  it('covers memory and tool-backed commands', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { handleTool } = await import('../tools/index.js');
+    vi.mocked(handleTool).mockImplementation(async (_ctx, name) => {
+      if (name === 'search') {
+        return { results: [{ id: '12345678-1234-1234-1234-123456789abc', score: 0.9, summary: 'Search result' }] };
+      }
+      return { ok: true, tool: name };
+    });
+
+    const context = createMockContext();
+    await runProgram(['list'], context);
+    await runProgram(['search', 'query'], context);
+    await runProgram(['show', '12345678-1234-1234-1234-123456789abc'], context);
+    await runProgram(['show', 'missing'], context);
+    await runProgram(['forget', '12345678-1234-1234-1234-123456789abc'], context);
+    await runProgram(['category', 'list'], context);
+    await runProgram(['category', 'get', 'policy'], context);
+    await runProgram(['category', 'set', 'policy', '--content', 'content'], context);
+    await runProgram(['backup', 'create'], context);
+    await runProgram(['backup', 'list'], context);
+    await runProgram(['backup', 'restore', 'backup.zip'], context);
+
+    expect(logSpy).toHaveBeenCalledWith('[12345678] (semantic) Remember this');
+    expect(logSpy).toHaveBeenCalledWith('[12345678] score: 0.900  Search result');
+    expect(errorSpy).toHaveBeenCalledWith('Memory missing not found.');
+  });
+
+  it('covers server and maintenance commands', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const execFileSync = vi.fn();
+    const randomBytes = vi.fn(() => ({ toString: () => 'token-1234' }));
+    vi.doMock('node:child_process', () => ({ execFileSync }));
+    vi.doMock('node:crypto', () => ({ randomBytes }));
+
+    const context = createMockContext();
+    await runProgram(['server', 'start', '--stdio']);
+    await runProgram(['server', 'status'], context);
+    await runProgram(['server', 'token']);
+    await runProgram(['gc', '--dry-run', '--tier', 'T2'], context);
+    await runProgram(['stats', '--by-tier', '--expiring'], context);
+    await runProgram(['health'], context);
+    await runProgram(['audit'], context);
+
+    expect(execFileSync).toHaveBeenCalledWith(
+      process.execPath,
+      expect.arrayContaining(['--stdio']),
+      { stdio: 'inherit' },
+    );
+    expect(logSpy).toHaveBeenCalledWith('New token: token-1234');
+    expect(logSpy).toHaveBeenCalledWith('Total memories: 10');
+    expect(logSpy).toHaveBeenCalledWith('  T0: 1');
+    expect(logSpy).toHaveBeenCalledWith('  12345678 T2 expires 2026-04-01T00:00:00.000Z Expiring soon');
+    expect(logSpy).toHaveBeenCalledWith('[2026-03-19T00:00:00.000Z] remember 12345678 ns:global client:cli');
+  });
+
+  it('covers tier and archive commands including missing-memory branches', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const context = createMockContext();
+    await runProgram(['tier', 'show', '12345678-1234-1234-1234-123456789abc'], context);
+    await runProgram(['tier', 'show', 'missing'], context);
+    await runProgram(['tier', 'set', '12345678-1234-1234-1234-123456789abc', 'T2'], context);
+    await runProgram(['tier', 'set', 'missing', 'T2'], context);
+    await runProgram(['tier', 'list', '--tier', 'T1'], context);
+    await runProgram(['archive', 'list'], context);
+    await runProgram(['archive', 'search', 'query'], context);
+    await runProgram(['archive', 'restore', 'arch-1'], context);
+
+    expect(errorSpy).toHaveBeenCalledWith('Memory missing not found.');
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ ok: true, id: '12345678-1234-1234-1234-123456789abc', tier: 'T2' }, null, 2));
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify([{ id: 'arch-1' }], null, 2));
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ restored: true }, null, 2));
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { fileURLToPath } from 'node:url';
 import { loadConfig, ensureDataDir } from '../config/index.js';
 import { SqliteStore } from '../storage/sqlite.js';
 import { QdrantStore } from '../storage/qdrant.js';
@@ -13,6 +14,7 @@ import { HealthService } from '../health/index.js';
 import { RetentionService } from '../backup/retention.js';
 import { MetricsCollector } from '../health/metrics.js';
 import { createLogger } from '../health/logger.js';
+import { CircuitBreaker } from '../resilience/index.js';
 import { handleTool, type ToolContext } from '../tools/index.js';
 
 async function createContext(): Promise<ToolContext> {
@@ -23,375 +25,390 @@ async function createContext(): Promise<ToolContext> {
   const sqlite = new SqliteStore(config.data_dir!);
   await sqlite.init();
 
-  const qdrant = new QdrantStore(config);
-  const embedding = createEmbeddingProvider(config);
+  const breakerOptions = {
+    failureThreshold: config.resilience.circuit_breaker.failure_threshold,
+    openWindowMs: config.resilience.circuit_breaker.open_window_ms,
+    halfOpenProbeCount: config.resilience.circuit_breaker.half_open_probe_count,
+  };
+  const embeddingBreaker = new CircuitBreaker(breakerOptions);
+  const qdrantBreaker = new CircuitBreaker(breakerOptions);
+  const metrics = new MetricsCollector(config);
+  const qdrant = new QdrantStore(config, qdrantBreaker);
+  const embedding = createEmbeddingProvider(config, { breaker: embeddingBreaker, metrics });
   const storage = new StorageManager(sqlite, qdrant, embedding);
 
   const pipeline = new WritePipeline(config, storage, embedding);
-  const searchService = new SearchService(config, storage, embedding);
+  const searchService = new SearchService(config, storage, embedding, metrics);
   const backupService = new BackupService(config, storage, logger);
-  const healthService = new HealthService(storage, embedding, config);
-  const metrics = new MetricsCollector(config);
+  const healthService = new HealthService(storage, embedding, config, {
+    openai_embedding: embeddingBreaker,
+    qdrant: qdrantBreaker,
+  });
 
   return { config, storage, embedding, pipeline, search: searchService, backup: backupService, health: healthService, metrics, logger };
 }
 
-const program = new Command()
-  .name('bhgbrain')
-  .description('BHGBrain companion CLI for managing persistent memory')
-  .version('1.0.0');
+export function createProgram(createContextImpl: typeof createContext = createContext): Command {
+  const program = new Command()
+    .name('bhgbrain')
+    .description('BHGBrain companion CLI for managing persistent memory')
+    .version('1.0.0');
 
-// -- Memory commands --
-
-program
-  .command('list')
-  .description('List recent memories')
-  .option('-l, --limit <n>', 'Max memories to show', '20')
-  .option('-n, --namespace <ns>', 'Namespace', 'global')
-  .action(async (opts) => {
-    const ctx = await createContext();
-    const memories = ctx.storage.sqlite.listMemories(opts.namespace, parseInt(opts.limit));
-    for (const m of memories) {
-      console.log(`[${m.id.substring(0, 8)}] (${m.type}) ${m.summary}`);
-      console.log(`  tags: ${m.tags.join(', ') || 'none'}  importance: ${m.importance}  created: ${m.created_at}`);
-    }
-    if (memories.length === 0) console.log('No memories found.');
-    ctx.storage.sqlite.close();
-  });
-
-program
-  .command('search <query>')
-  .description('Search memories')
-  .option('-m, --mode <mode>', 'Search mode (semantic|fulltext|hybrid)', 'hybrid')
-  .option('-l, --limit <n>', 'Max results', '10')
-  .option('-n, --namespace <ns>', 'Namespace', 'global')
-  .action(async (query, opts) => {
-    const ctx = await createContext();
-    const result = await handleTool(ctx, 'search', { query, mode: opts.mode, limit: parseInt(opts.limit), namespace: opts.namespace });
-    const data = result as { results: any[] };
-    if (data.results) {
-      for (const r of data.results) {
-        console.log(`[${r.id.substring(0, 8)}] score: ${r.score.toFixed(3)}  ${r.summary}`);
+  program
+    .command('list')
+    .description('List recent memories')
+    .option('-l, --limit <n>', 'Max memories to show', '20')
+    .option('-n, --namespace <ns>', 'Namespace', 'global')
+    .action(async (opts) => {
+      const ctx = await createContextImpl();
+      const memories = ctx.storage.sqlite.listMemories(opts.namespace, parseInt(opts.limit));
+      for (const m of memories) {
+        console.log(`[${m.id.substring(0, 8)}] (${m.type}) ${m.summary}`);
+        console.log(`  tags: ${m.tags.join(', ') || 'none'}  importance: ${m.importance}  created: ${m.created_at}`);
       }
-      if (data.results.length === 0) console.log('No results.');
-    } else {
+      if (memories.length === 0) console.log('No memories found.');
+      ctx.storage.sqlite.close();
+    });
+
+  program
+    .command('search <query>')
+    .description('Search memories')
+    .option('-m, --mode <mode>', 'Search mode (semantic|fulltext|hybrid)', 'hybrid')
+    .option('-l, --limit <n>', 'Max results', '10')
+    .option('-n, --namespace <ns>', 'Namespace', 'global')
+    .action(async (query, opts) => {
+      const ctx = await createContextImpl();
+      const result = await handleTool(ctx, 'search', { query, mode: opts.mode, limit: parseInt(opts.limit), namespace: opts.namespace });
+      const data = result as { results: Array<{ id: string; score: number; summary: string }> };
+      if (data.results) {
+        for (const r of data.results) {
+          console.log(`[${r.id.substring(0, 8)}] score: ${r.score.toFixed(3)}  ${r.summary}`);
+        }
+        if (data.results.length === 0) console.log('No results.');
+      } else {
+        console.log(JSON.stringify(result, null, 2));
+      }
+      ctx.storage.sqlite.close();
+    });
+
+  program
+    .command('show <id>')
+    .description('Show full memory details')
+    .action(async (id) => {
+      const ctx = await createContextImpl();
+      const mem = ctx.storage.sqlite.getMemoryById(id);
+      if (!mem) {
+        console.error(`Memory ${id} not found.`);
+      } else {
+        console.log(JSON.stringify(mem, null, 2));
+      }
+      ctx.storage.sqlite.close();
+    });
+
+  program
+    .command('forget <id>')
+    .description('Delete a memory')
+    .action(async (id) => {
+      const ctx = await createContextImpl();
+      const result = await handleTool(ctx, 'forget', { id });
       console.log(JSON.stringify(result, null, 2));
-    }
-    ctx.storage.sqlite.close();
-  });
+      ctx.storage.sqlite.close();
+    });
 
-program
-  .command('show <id>')
-  .description('Show full memory details')
-  .action(async (id) => {
-    const ctx = await createContext();
-    const mem = ctx.storage.sqlite.getMemoryById(id);
-    if (!mem) {
-      console.error(`Memory ${id} not found.`);
-    } else {
-      console.log(JSON.stringify(mem, null, 2));
-    }
-    ctx.storage.sqlite.close();
-  });
+  const categoryCmd = program.command('category').description('Manage persistent categories');
 
-program
-  .command('forget <id>')
-  .description('Delete a memory')
-  .action(async (id) => {
-    const ctx = await createContext();
-    const result = await handleTool(ctx, 'forget', { id });
-    console.log(JSON.stringify(result, null, 2));
-    ctx.storage.sqlite.close();
-  });
+  categoryCmd
+    .command('list')
+    .description('List all categories')
+    .action(async () => {
+      const ctx = await createContextImpl();
+      const result = await handleTool(ctx, 'category', { action: 'list' });
+      console.log(JSON.stringify(result, null, 2));
+      ctx.storage.sqlite.close();
+    });
 
-// -- Category commands --
+  categoryCmd
+    .command('get <name>')
+    .description('Get category content')
+    .action(async (name) => {
+      const ctx = await createContextImpl();
+      const result = await handleTool(ctx, 'category', { action: 'get', name });
+      console.log(JSON.stringify(result, null, 2));
+      ctx.storage.sqlite.close();
+    });
 
-const categoryCmd = program.command('category').description('Manage persistent categories');
-
-categoryCmd
-  .command('list')
-  .description('List all categories')
-  .action(async () => {
-    const ctx = await createContext();
-    const result = await handleTool(ctx, 'category', { action: 'list' });
-    console.log(JSON.stringify(result, null, 2));
-    ctx.storage.sqlite.close();
-  });
-
-categoryCmd
-  .command('get <name>')
-  .description('Get category content')
-  .action(async (name) => {
-    const ctx = await createContext();
-    const result = await handleTool(ctx, 'category', { action: 'get', name });
-    console.log(JSON.stringify(result, null, 2));
-    ctx.storage.sqlite.close();
-  });
-
-categoryCmd
-  .command('set <name>')
-  .description('Set category content')
-  .option('-s, --slot <slot>', 'Category slot', 'custom')
-  .option('-c, --content <text>', 'Content text')
-  .option('-f, --file <path>', 'Read content from file')
-  .action(async (name, opts) => {
-    const ctx = await createContext();
-    let content = opts.content;
-    if (opts.file) {
-      const { readFileSync } = await import('node:fs');
-      content = readFileSync(opts.file, 'utf-8');
-    }
-    if (!content) {
-      console.error('Provide --content or --file');
-      process.exit(1);
-    }
-    const result = await handleTool(ctx, 'category', { action: 'set', name, slot: opts.slot, content });
-    console.log(JSON.stringify(result, null, 2));
-    ctx.storage.sqlite.close();
-  });
-
-// -- Backup commands --
-
-const backupCmd = program.command('backup').description('Manage backups');
-
-backupCmd
-  .command('create')
-  .description('Create a backup')
-  .action(async () => {
-    const ctx = await createContext();
-    const result = await handleTool(ctx, 'backup', { action: 'create' });
-    console.log(JSON.stringify(result, null, 2));
-    ctx.storage.sqlite.close();
-  });
-
-backupCmd
-  .command('list')
-  .description('List backups')
-  .action(async () => {
-    const ctx = await createContext();
-    const result = await handleTool(ctx, 'backup', { action: 'list' });
-    console.log(JSON.stringify(result, null, 2));
-    ctx.storage.sqlite.close();
-  });
-
-backupCmd
-  .command('restore <path>')
-  .description('Restore from backup')
-  .action(async (path) => {
-    const ctx = await createContext();
-    const result = await handleTool(ctx, 'backup', { action: 'restore', path });
-    console.log(JSON.stringify(result, null, 2));
-    ctx.storage.sqlite.close();
-  });
-
-// -- Server commands --
-
-const serverCmd = program.command('server').description('Server management');
-
-serverCmd
-  .command('start')
-  .description('Start the BHGBrain server')
-  .option('--stdio', 'Use stdio transport')
-  .action(async (opts) => {
-    // Delegate to main server entry
-    const args = opts.stdio ? ['--stdio'] : [];
-    const { execFileSync } = await import('node:child_process');
-    execFileSync(process.execPath, [new URL('../index.js', import.meta.url).pathname, ...args], { stdio: 'inherit' });
-  });
-
-serverCmd
-  .command('status')
-  .description('Check server health')
-  .action(async () => {
-    const ctx = await createContext();
-    const health = await ctx.health.check();
-    console.log(JSON.stringify(health, null, 2));
-    ctx.storage.sqlite.close();
-  });
-
-serverCmd
-  .command('token')
-  .description('Rotate bearer token')
-  .action(async () => {
-    const { randomBytes } = await import('node:crypto');
-    const token = randomBytes(32).toString('hex');
-    console.log(`New token: ${token}`);
-    console.log(`Set BHGBRAIN_TOKEN=${token} in your environment.`);
-  });
-
-// -- Maintenance commands --
-
-program
-  .command('gc')
-  .description('Run retention cleanup')
-  .option('--dry-run', 'Report candidates without deleting')
-  .option('--tier <tier>', 'Limit cleanup to a single tier (T1|T2|T3)')
-  .action(async (opts) => {
-    const ctx = await createContext();
-    const retention = new RetentionService(ctx.config, ctx.storage);
-    const result = await retention.runGc({ dryRun: Boolean(opts.dryRun), tier: opts.tier });
-    console.log(JSON.stringify(result, null, 2));
-    ctx.storage.sqlite.close();
-  });
-
-program
-  .command('stats')
-  .description('Show memory statistics')
-  .option('--by-tier', 'Include tier breakdown')
-  .option('--expiring', 'Show memories expiring soon')
-  .action(async () => {
-    const ctx = await createContext();
-    const retention = new RetentionService(ctx.config, ctx.storage);
-    const total = ctx.storage.sqlite.countMemories();
-    const collections = ctx.storage.sqlite.listCollections();
-    const categories = ctx.storage.sqlite.listCategories();
-    const dbSize = ctx.storage.sqlite.getDbSizeBytes();
-
-    console.log(`Total memories: ${total}`);
-    console.log(`Collections: ${collections.length}`);
-    for (const c of collections) {
-      console.log(`  ${c.name}: ${c.count} memories`);
-    }
-    console.log(`Categories: ${categories.length}`);
-    for (const c of categories) {
-      console.log(`  ${c.name} (${c.slot}) rev ${c.revision}`);
-    }
-    console.log(`DB size: ${(dbSize / 1024).toFixed(1)} KB`);
-    const tierStats = retention.getTierStats();
-    console.log(`Archived memories: ${tierStats.archived}`);
-    console.log(`Unsynced vectors: ${tierStats.unsynced_vectors}`);
-    if (process.argv.includes('--by-tier')) {
-      for (const [tier, count] of Object.entries(tierStats.counts)) {
-        console.log(`  ${tier}: ${count}`);
+  categoryCmd
+    .command('set <name>')
+    .description('Set category content')
+    .option('-s, --slot <slot>', 'Category slot', 'custom')
+    .option('-c, --content <text>', 'Content text')
+    .option('-f, --file <path>', 'Read content from file')
+    .action(async (name, opts) => {
+      const ctx = await createContextImpl();
+      let content = opts.content;
+      if (opts.file) {
+        const { readFileSync } = await import('node:fs');
+        content = readFileSync(opts.file, 'utf-8');
       }
-    }
-    if (process.argv.includes('--expiring')) {
-      const expiring = retention.listExpiringSoon(20);
-      for (const mem of expiring) {
-        console.log(`  ${mem.id.substring(0, 8)} ${mem.retention_tier} expires ${mem.expires_at} ${mem.summary}`);
+      if (!content) {
+        console.error('Provide --content or --file');
+        process.exit(1);
+        return;
       }
-    }
-    ctx.storage.sqlite.close();
-  });
+      const result = await handleTool(ctx, 'category', { action: 'set', name, slot: opts.slot, content });
+      console.log(JSON.stringify(result, null, 2));
+      ctx.storage.sqlite.close();
+    });
 
-const tierCmd = program.command('tier').description('Inspect and manage retention tiers');
+  const backupCmd = program.command('backup').description('Manage backups');
 
-tierCmd
-  .command('show <id>')
-  .description('Show retention details for a memory')
-  .action(async (id) => {
-    const ctx = await createContext();
-    const memory = ctx.storage.sqlite.getMemoryById(id);
-    if (!memory) {
-      console.error(`Memory ${id} not found.`);
-      process.exitCode = 1;
-    } else {
-      console.log(JSON.stringify({
-        id: memory.id,
-        retention_tier: memory.retention_tier,
-        expires_at: memory.expires_at,
-        decay_eligible: memory.decay_eligible,
-        review_due: memory.review_due,
-      }, null, 2));
-    }
-    ctx.storage.sqlite.close();
-  });
+  backupCmd
+    .command('create')
+    .description('Create a backup')
+    .action(async () => {
+      const ctx = await createContextImpl();
+      const result = await handleTool(ctx, 'backup', { action: 'create' });
+      console.log(JSON.stringify(result, null, 2));
+      ctx.storage.sqlite.close();
+    });
 
-tierCmd
-  .command('set <id> <tier>')
-  .description('Set retention tier for a memory')
-  .action(async (id, tier) => {
-    const ctx = await createContext();
-    const memory = ctx.storage.sqlite.getMemoryById(id);
-    if (!memory) {
-      console.error(`Memory ${id} not found.`);
-      process.exitCode = 1;
-    } else {
+  backupCmd
+    .command('list')
+    .description('List backups')
+    .action(async () => {
+      const ctx = await createContextImpl();
+      const result = await handleTool(ctx, 'backup', { action: 'list' });
+      console.log(JSON.stringify(result, null, 2));
+      ctx.storage.sqlite.close();
+    });
+
+  backupCmd
+    .command('restore <path>')
+    .description('Restore from backup')
+    .action(async (path) => {
+      const ctx = await createContextImpl();
+      const result = await handleTool(ctx, 'backup', { action: 'restore', path });
+      console.log(JSON.stringify(result, null, 2));
+      ctx.storage.sqlite.close();
+    });
+
+  const serverCmd = program.command('server').description('Server management');
+
+  serverCmd
+    .command('start')
+    .description('Start the BHGBrain server')
+    .option('--stdio', 'Use stdio transport')
+    .action(async (opts) => {
+      const args = opts.stdio ? ['--stdio'] : [];
+      const { execFileSync } = await import('node:child_process');
+      execFileSync(process.execPath, [new URL('../index.js', import.meta.url).pathname, ...args], { stdio: 'inherit' });
+    });
+
+  serverCmd
+    .command('status')
+    .description('Check server health')
+    .action(async () => {
+      const ctx = await createContextImpl();
+      const health = await ctx.health.check();
+      console.log(JSON.stringify(health, null, 2));
+      ctx.storage.sqlite.close();
+    });
+
+  serverCmd
+    .command('token')
+    .description('Rotate bearer token')
+    .action(async () => {
+      const { randomBytes } = await import('node:crypto');
+      const token = randomBytes(32).toString('hex');
+      console.log(`New token: ${token}`);
+      console.log(`Set BHGBRAIN_TOKEN=${token} in your environment.`);
+    });
+
+  program
+    .command('gc')
+    .description('Run retention cleanup')
+    .option('--dry-run', 'Report candidates without deleting')
+    .option('--tier <tier>', 'Limit cleanup to a single tier (T1|T2|T3)')
+    .action(async (opts) => {
+      const ctx = await createContextImpl();
       const retention = new RetentionService(ctx.config, ctx.storage);
-      const metadata = retention.buildMetadataForTier(tier);
-      ctx.storage.sqlite.updateMemory(id, {
-        retention_tier: tier,
-        expires_at: metadata.expires_at,
-        decay_eligible: metadata.decay_eligible,
-        review_due: metadata.review_due,
-        updated_at: new Date().toISOString(),
-      });
-      ctx.storage.sqlite.flushIfDirty();
-      console.log(JSON.stringify({ ok: true, id, tier }, null, 2));
-    }
-    ctx.storage.sqlite.close();
-  });
+      const result = await retention.runGc({ dryRun: Boolean(opts.dryRun), tier: opts.tier });
+      console.log(JSON.stringify(result, null, 2));
+      ctx.storage.sqlite.close();
+    });
 
-tierCmd
-  .command('list')
-  .description('List memories by retention tier')
-  .requiredOption('--tier <tier>', 'Tier to list')
-  .action(async (opts) => {
-    const ctx = await createContext();
-    const memories = ctx.storage.sqlite.listMemories('global', 200).filter(mem => mem.retention_tier === opts.tier);
-    console.log(JSON.stringify(memories.map(mem => ({
-      id: mem.id,
-      tier: mem.retention_tier,
-      expires_at: mem.expires_at,
-      summary: mem.summary,
-    })), null, 2));
-    ctx.storage.sqlite.close();
-  });
+  program
+    .command('stats')
+    .description('Show memory statistics')
+    .option('--by-tier', 'Include tier breakdown')
+    .option('--expiring', 'Show memories expiring soon')
+    .action(async (opts) => {
+      const ctx = await createContextImpl();
+      const retention = new RetentionService(ctx.config, ctx.storage);
+      const total = ctx.storage.sqlite.countMemories();
+      const collections = ctx.storage.sqlite.listCollections();
+      const categories = ctx.storage.sqlite.listCategories();
+      const dbSize = ctx.storage.sqlite.getDbSizeBytes();
 
-const archiveCmd = program.command('archive').description('Inspect and restore archived memories');
+      console.log(`Total memories: ${total}`);
+      console.log(`Collections: ${collections.length}`);
+      for (const c of collections) {
+        console.log(`  ${c.name}: ${c.count} memories`);
+      }
+      console.log(`Categories: ${categories.length}`);
+      for (const c of categories) {
+        console.log(`  ${c.name} (${c.slot}) rev ${c.revision}`);
+      }
+      console.log(`DB size: ${(dbSize / 1024).toFixed(1)} KB`);
+      const tierStats = retention.getTierStats();
+      console.log(`Archived memories: ${tierStats.archived}`);
+      console.log(`Unsynced vectors: ${tierStats.unsynced_vectors}`);
+      if (opts.byTier) {
+        for (const [tier, count] of Object.entries(tierStats.counts)) {
+          console.log(`  ${tier}: ${count}`);
+        }
+      }
+      if (opts.expiring) {
+        const expiring = retention.listExpiringSoon(20);
+        for (const mem of expiring) {
+          console.log(`  ${mem.id.substring(0, 8)} ${mem.retention_tier} expires ${mem.expires_at} ${mem.summary}`);
+        }
+      }
+      ctx.storage.sqlite.close();
+    });
 
-archiveCmd
-  .command('list')
-  .description('List archived memory summaries')
-  .action(async () => {
-    const ctx = await createContext();
-    const retention = new RetentionService(ctx.config, ctx.storage);
-    console.log(JSON.stringify(retention.listArchive(), null, 2));
-    ctx.storage.sqlite.close();
-  });
+  const tierCmd = program.command('tier').description('Inspect and manage retention tiers');
 
-archiveCmd
-  .command('search <query>')
-  .description('Search archived memory summaries')
-  .action(async (query) => {
-    const ctx = await createContext();
-    const retention = new RetentionService(ctx.config, ctx.storage);
-    console.log(JSON.stringify(retention.searchArchive(query), null, 2));
-    ctx.storage.sqlite.close();
-  });
+  tierCmd
+    .command('show <id>')
+    .description('Show retention details for a memory')
+    .action(async (id) => {
+      const ctx = await createContextImpl();
+      const memory = ctx.storage.sqlite.getMemoryById(id);
+      if (!memory) {
+        console.error(`Memory ${id} not found.`);
+        process.exitCode = 1;
+      } else {
+        console.log(JSON.stringify({
+          id: memory.id,
+          retention_tier: memory.retention_tier,
+          expires_at: memory.expires_at,
+          decay_eligible: memory.decay_eligible,
+          review_due: memory.review_due,
+        }, null, 2));
+      }
+      ctx.storage.sqlite.close();
+    });
 
-archiveCmd
-  .command('restore <id>')
-  .description('Restore an archived summary into active memory')
-  .action(async (id) => {
-    const ctx = await createContext();
-    const retention = new RetentionService(ctx.config, ctx.storage);
-    console.log(JSON.stringify(await retention.restoreArchive(id), null, 2));
-    ctx.storage.sqlite.close();
-  });
+  tierCmd
+    .command('set <id> <tier>')
+    .description('Set retention tier for a memory')
+    .action(async (id, tier) => {
+      const ctx = await createContextImpl();
+      const memory = ctx.storage.sqlite.getMemoryById(id);
+      if (!memory) {
+        console.error(`Memory ${id} not found.`);
+        process.exitCode = 1;
+      } else {
+        const retention = new RetentionService(ctx.config, ctx.storage);
+        const metadata = retention.buildMetadataForTier(tier);
+        ctx.storage.sqlite.updateMemory(id, {
+          retention_tier: tier,
+          expires_at: metadata.expires_at,
+          decay_eligible: metadata.decay_eligible,
+          review_due: metadata.review_due,
+          updated_at: new Date().toISOString(),
+        });
+        ctx.storage.sqlite.flushIfDirty();
+        console.log(JSON.stringify({ ok: true, id, tier }, null, 2));
+      }
+      ctx.storage.sqlite.close();
+    });
 
-program
-  .command('health')
-  .description('Check system health')
-  .action(async () => {
-    const ctx = await createContext();
-    const health = await ctx.health.check();
-    console.log(JSON.stringify(health, null, 2));
-    ctx.storage.sqlite.close();
-  });
+  tierCmd
+    .command('list')
+    .description('List memories by retention tier')
+    .requiredOption('--tier <tier>', 'Tier to list')
+    .action(async (opts) => {
+      const ctx = await createContextImpl();
+      const memories = ctx.storage.sqlite.listMemories('global', 200).filter(mem => mem.retention_tier === opts.tier);
+      console.log(JSON.stringify(memories.map(mem => ({
+        id: mem.id,
+        tier: mem.retention_tier,
+        expires_at: mem.expires_at,
+        summary: mem.summary,
+      })), null, 2));
+      ctx.storage.sqlite.close();
+    });
 
-program
-  .command('audit')
-  .description('Show audit log')
-  .option('-l, --limit <n>', 'Max entries', '50')
-  .action(async (opts) => {
-    const ctx = await createContext();
-    const entries = ctx.storage.sqlite.listAudit(parseInt(opts.limit));
-    for (const e of entries) {
-      console.log(`[${e.timestamp}] ${e.operation} ${e.memory_id ?? ''} ns:${e.namespace} client:${e.client_id}`);
-    }
-    if (entries.length === 0) console.log('No audit entries.');
-    ctx.storage.sqlite.close();
-  });
+  const archiveCmd = program.command('archive').description('Inspect and restore archived memories');
 
-program.parse();
+  archiveCmd
+    .command('list')
+    .description('List archived memory summaries')
+    .action(async () => {
+      const ctx = await createContextImpl();
+      const retention = new RetentionService(ctx.config, ctx.storage);
+      console.log(JSON.stringify(retention.listArchive(), null, 2));
+      ctx.storage.sqlite.close();
+    });
+
+  archiveCmd
+    .command('search <query>')
+    .description('Search archived memory summaries')
+    .action(async (query) => {
+      const ctx = await createContextImpl();
+      const retention = new RetentionService(ctx.config, ctx.storage);
+      console.log(JSON.stringify(retention.searchArchive(query), null, 2));
+      ctx.storage.sqlite.close();
+    });
+
+  archiveCmd
+    .command('restore <id>')
+    .description('Restore an archived summary into active memory')
+    .action(async (id) => {
+      const ctx = await createContextImpl();
+      const retention = new RetentionService(ctx.config, ctx.storage);
+      console.log(JSON.stringify(await retention.restoreArchive(id), null, 2));
+      ctx.storage.sqlite.close();
+    });
+
+  program
+    .command('health')
+    .description('Check system health')
+    .action(async () => {
+      const ctx = await createContextImpl();
+      const health = await ctx.health.check();
+      console.log(JSON.stringify(health, null, 2));
+      ctx.storage.sqlite.close();
+    });
+
+  program
+    .command('audit')
+    .description('Show audit log')
+    .option('-l, --limit <n>', 'Max entries', '50')
+    .action(async (opts) => {
+      const ctx = await createContextImpl();
+      const entries = ctx.storage.sqlite.listAudit(parseInt(opts.limit));
+      for (const e of entries) {
+        console.log(`[${e.timestamp}] ${e.operation} ${e.memory_id ?? ''} ns:${e.namespace} client:${e.client_id}`);
+      }
+      if (entries.length === 0) console.log('No audit entries.');
+      ctx.storage.sqlite.close();
+    });
+
+  return program;
+}
+
+export async function runCli(argv = process.argv): Promise<void> {
+  try {
+    await createProgram().parseAsync(argv);
+  } catch (err) {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  void runCli();
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -69,6 +69,13 @@ const ConfigSchema = z.object({
     enabled: z.boolean().default(true),
     similarity_threshold: z.number().min(0).max(1).default(0.92),
   }).default({}),
+  resilience: z.object({
+    circuit_breaker: z.object({
+      failure_threshold: z.number().int().min(1).default(5),
+      open_window_ms: z.number().int().min(1000).default(30000),
+      half_open_probe_count: z.number().int().min(1).default(1),
+    }).default({}),
+  }).default({}),
   search: z.object({
     hybrid_weights: z.object({
       semantic: z.number().min(0).max(1).default(0.7),
@@ -101,6 +108,7 @@ const ConfigSchema = z.object({
 });
 
 export type BrainConfig = z.infer<typeof ConfigSchema>;
+export type ResilienceConfig = BrainConfig['resilience'];
 
 export function getDefaultDataDir(): string {
   if (process.platform === 'win32') {

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -12,6 +12,8 @@ export type RetentionTier = 'T0' | 'T1' | 'T2' | 'T3';
 
 export type HealthStatus = 'healthy' | 'degraded' | 'unhealthy';
 
+export type VectorReconciliationState = 'reconciled' | 'reconciling' | 'pending';
+
 export type ErrorCode =
   | 'INVALID_INPUT'
   | 'NOT_FOUND'
@@ -100,12 +102,24 @@ export interface ComponentHealth {
   message?: string;
 }
 
+export interface VectorReconciliationStatus extends ComponentHealth {
+  state: VectorReconciliationState;
+  unsynced_vectors: number;
+}
+
+export interface RestoreResult {
+  memory_count: number;
+  metadata_activated: boolean;
+  vector_reconciliation: VectorReconciliationStatus;
+}
+
 export interface HealthSnapshot {
   status: HealthStatus;
   components: {
     sqlite: ComponentHealth;
     qdrant: ComponentHealth;
     embedding: ComponentHealth;
+    vector_reconciliation: VectorReconciliationStatus;
     retention?: ComponentHealth;
   };
   memory_count: number;

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -111,6 +111,7 @@ export interface HealthSnapshot {
   memory_count: number;
   db_size_bytes: number;
   uptime_seconds: number;
+  circuitBreakers?: Record<string, 'closed' | 'open' | 'half-open'>;
   retention?: {
     counts_by_tier: Record<RetentionTier, number>;
     expiring_soon: number;

--- a/src/embedding/index.test.ts
+++ b/src/embedding/index.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DegradedEmbeddingProvider, OpenAIEmbeddingProvider, createEmbeddingProvider } from './index.js';
+import type { BrainConfig } from '../config/index.js';
+import type { CircuitBreaker } from '../resilience/index.js';
+
+describe('OpenAIEmbeddingProvider', () => {
+  function createConfig(): BrainConfig {
+    return {
+      data_dir: 'test-data',
+      embedding: { provider: 'openai', model: 'test-model', api_key_env: 'OPENAI_API_KEY', dimensions: 3 },
+      qdrant: { mode: 'embedded', embedded_path: './qdrant', external_url: null, api_key_env: null },
+      transport: {
+        http: { enabled: true, host: '127.0.0.1', port: 3721, bearer_token_env: 'BHGBRAIN_TOKEN' },
+        stdio: { enabled: true },
+      },
+      defaults: {
+        namespace: 'global',
+        collection: 'general',
+        recall_limit: 5,
+        min_score: 0.6,
+        auto_inject_limit: 10,
+        max_response_chars: 50000,
+      },
+      retention: {
+        decay_after_days: 180,
+        max_db_size_gb: 2,
+        max_memories: 500000,
+        warn_at_percent: 80,
+        tier_ttl: { T0: null, T1: 365, T2: 90, T3: 30 },
+        tier_budgets: { T0: null, T1: 100000, T2: 200000, T3: 200000 },
+        auto_promote_access_threshold: 5,
+        sliding_window_enabled: true,
+        archive_before_delete: true,
+        cleanup_schedule: '0 2 * * *',
+        pre_expiry_warning_days: 7,
+        compaction_deleted_threshold: 0.1,
+      },
+      deduplication: { enabled: true, similarity_threshold: 0.92 },
+      resilience: {
+        circuit_breaker: {
+          failure_threshold: 1,
+          open_window_ms: 30000,
+          half_open_probe_count: 1,
+        },
+      },
+      search: { hybrid_weights: { semantic: 0.7, fulltext: 0.3 } },
+      security: {
+        require_loopback_http: true,
+        allow_unauthenticated_http: false,
+        log_redaction: true,
+        rate_limit_rpm: 100,
+        max_request_size_bytes: 1048576,
+      },
+      auto_inject: { max_chars: 30000, max_tokens: null },
+      observability: { metrics_enabled: false, structured_logging: true, log_level: 'info' },
+      pipeline: {
+        extraction_enabled: true,
+        extraction_model: 'gpt-4o-mini',
+        extraction_model_env: 'BHGBRAIN_EXTRACTION_API_KEY',
+        fallback_to_threshold_dedup: true,
+      },
+      auto_summarize: true,
+    };
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it('invokes the breaker for embed calls', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    const breaker = {
+      execute: vi.fn(async <T>(fn: () => Promise<T>) => fn()),
+    } as unknown as CircuitBreaker;
+
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [{ index: 0, embedding: [0.1, 0.2, 0.3] }],
+    }), { status: 200 })));
+
+    const provider = new OpenAIEmbeddingProvider(createConfig(), breaker);
+    await expect(provider.embed('hello')).resolves.toEqual([0.1, 0.2, 0.3]);
+    expect(breaker.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves response ordering by index in embedBatch', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [
+        { index: 1, embedding: [2, 2, 2] },
+        { index: 0, embedding: [1, 1, 1] },
+      ],
+    }), { status: 200 })));
+
+    const provider = new OpenAIEmbeddingProvider(createConfig());
+    await expect(provider.embedBatch(['a', 'b'])).resolves.toEqual([[1, 1, 1], [2, 2, 2]]);
+  });
+
+  it('wraps network failures as embeddingUnavailable errors', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('network down');
+    }));
+
+    const provider = new OpenAIEmbeddingProvider(createConfig());
+    await expect(provider.embed('hello')).rejects.toThrow('Embedding provider unreachable: network down');
+  });
+
+  it('includes HTTP status code in embedding API failures', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('slow down', { status: 429 })));
+
+    const provider = new OpenAIEmbeddingProvider(createConfig());
+    await expect(provider.embed('hello')).rejects.toThrow('Embedding API error 429');
+  });
+
+  it('bypasses the breaker during health checks', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    const breaker = {
+      execute: vi.fn(async <T>(fn: () => Promise<T>) => fn()),
+    } as unknown as CircuitBreaker;
+
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [{ index: 0, embedding: [0.1, 0.2, 0.3] }],
+    }), { status: 200 })));
+
+    const provider = new OpenAIEmbeddingProvider(createConfig(), breaker);
+    await expect(provider.healthCheck()).resolves.toBe(true);
+    expect(breaker.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns false from healthCheck when the probe fails', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('unavailable', { status: 500 })));
+
+    const provider = new OpenAIEmbeddingProvider(createConfig());
+    await expect(provider.healthCheck()).resolves.toBe(false);
+  });
+
+  it('exposes degraded provider behavior and factory fallback', async () => {
+    const config = createConfig();
+    const degraded = new DegradedEmbeddingProvider(config);
+
+    await expect(degraded.embed()).rejects.toThrow('missing API credentials');
+    await expect(degraded.embedBatch()).rejects.toThrow('missing API credentials');
+    await expect(degraded.healthCheck()).resolves.toBe(false);
+
+    const created = createEmbeddingProvider(config);
+    expect(created).toBeInstanceOf(DegradedEmbeddingProvider);
+  });
+
+  it('throws when createEmbeddingProvider receives an unknown provider', () => {
+    const config = {
+      ...createConfig(),
+      embedding: {
+        ...createConfig().embedding,
+        provider: 'unknown',
+      },
+    } as unknown as BrainConfig;
+
+    expect(() => createEmbeddingProvider(config)).toThrow('Unknown embedding provider: unknown');
+  });
+});

--- a/src/embedding/index.ts
+++ b/src/embedding/index.ts
@@ -1,5 +1,6 @@
 import type { BrainConfig } from '../config/index.js';
 import type { MetricsCollector } from '../health/metrics.js';
+import type { CircuitBreaker } from '../resilience/index.js';
 import { embeddingUnavailable } from '../errors/index.js';
 
 export interface EmbeddingProvider {
@@ -18,6 +19,7 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
 
   constructor(
     config: BrainConfig,
+    private readonly breaker?: CircuitBreaker,
     private readonly metrics?: MetricsCollector,
   ) {
     this.model = config.embedding.model;
@@ -36,25 +38,47 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
 
   async embedBatch(texts: string[]): Promise<number[][]> {
     const start = Date.now();
-    let response: Response;
     try {
-      response = await fetch(`${this.baseUrl}/embeddings`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          model: this.model,
-          input: texts,
-        }),
-      });
+      const response = await this.requestEmbeddings(texts, true);
+      return await this.parseEmbeddingsResponse(response);
     } catch (err) {
       throw embeddingUnavailable(`Embedding provider unreachable: ${(err as Error).message}`);
     } finally {
       this.metrics?.recordHistogram('embedding_embed_batch_ms', Date.now() - start);
     }
+  }
 
+  async healthCheck(): Promise<boolean> {
+    try {
+      const response = await this.requestEmbeddings(['health check'], false);
+      await this.parseEmbeddingsResponse(response);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async requestEmbeddings(texts: string[], useBreaker: boolean): Promise<Response> {
+    const executeFetch = () => fetch(`${this.baseUrl}/embeddings`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: this.model,
+        input: texts,
+      }),
+    });
+
+    if (useBreaker && this.breaker) {
+      return this.breaker.execute(executeFetch);
+    }
+
+    return executeFetch();
+  }
+
+  private async parseEmbeddingsResponse(response: Response): Promise<number[][]> {
     if (!response.ok) {
       const body = await response.text().catch(() => '');
       throw embeddingUnavailable(`Embedding API error ${response.status}: ${body.slice(0, 200)}`);
@@ -67,15 +91,6 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
     return data.data
       .sort((a, b) => a.index - b.index)
       .map(d => d.embedding);
-  }
-
-  async healthCheck(): Promise<boolean> {
-    try {
-      await this.embed('health check');
-      return true;
-    } catch {
-      return false;
-    }
   }
 }
 
@@ -108,12 +123,12 @@ export class DegradedEmbeddingProvider implements EmbeddingProvider {
 
 export function createEmbeddingProvider(
   config: BrainConfig,
-  options?: { metrics?: MetricsCollector },
+  options?: { breaker?: CircuitBreaker; metrics?: MetricsCollector },
 ): EmbeddingProvider {
   switch (config.embedding.provider) {
     case 'openai':
       try {
-        return new OpenAIEmbeddingProvider(config, options?.metrics);
+        return new OpenAIEmbeddingProvider(config, options?.breaker, options?.metrics);
       } catch {
         // Missing credentials: start in degraded mode
         return new DegradedEmbeddingProvider(config);

--- a/src/embedding/index.ts
+++ b/src/embedding/index.ts
@@ -1,4 +1,5 @@
 import type { BrainConfig } from '../config/index.js';
+import type { MetricsCollector } from '../health/metrics.js';
 import { embeddingUnavailable } from '../errors/index.js';
 
 export interface EmbeddingProvider {
@@ -15,7 +16,10 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
   private apiKey: string;
   private baseUrl = 'https://api.openai.com/v1';
 
-  constructor(config: BrainConfig) {
+  constructor(
+    config: BrainConfig,
+    private readonly metrics?: MetricsCollector,
+  ) {
     this.model = config.embedding.model;
     this.dimensions = config.embedding.dimensions;
     const key = process.env[config.embedding.api_key_env];
@@ -31,6 +35,7 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
   }
 
   async embedBatch(texts: string[]): Promise<number[][]> {
+    const start = Date.now();
     let response: Response;
     try {
       response = await fetch(`${this.baseUrl}/embeddings`, {
@@ -46,6 +51,8 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
       });
     } catch (err) {
       throw embeddingUnavailable(`Embedding provider unreachable: ${(err as Error).message}`);
+    } finally {
+      this.metrics?.recordHistogram('embedding_embed_batch_ms', Date.now() - start);
     }
 
     if (!response.ok) {
@@ -99,11 +106,14 @@ export class DegradedEmbeddingProvider implements EmbeddingProvider {
   }
 }
 
-export function createEmbeddingProvider(config: BrainConfig): EmbeddingProvider {
+export function createEmbeddingProvider(
+  config: BrainConfig,
+  options?: { metrics?: MetricsCollector },
+): EmbeddingProvider {
   switch (config.embedding.provider) {
     case 'openai':
       try {
-        return new OpenAIEmbeddingProvider(config);
+        return new OpenAIEmbeddingProvider(config, options?.metrics);
       } catch {
         // Missing credentials: start in degraded mode
         return new DegradedEmbeddingProvider(config);

--- a/src/health/index.test.ts
+++ b/src/health/index.test.ts
@@ -1,77 +1,177 @@
 import { describe, it, expect, vi } from 'vitest';
 import { HealthService } from './index.js';
 import { DegradedEmbeddingProvider } from '../embedding/index.js';
+import { CircuitBreaker } from '../resilience/index.js';
+import type { BrainConfig } from '../config/index.js';
+import type { StorageManager } from '../storage/index.js';
+import type { EmbeddingProvider } from '../embedding/index.js';
 
 describe('HealthService', () => {
-  function createMocks(embeddingOk = true, degraded = false) {
-    const storage = {
+  function createConfig(): BrainConfig {
+    return {
+      data_dir: 'test-data',
+      embedding: { provider: 'openai', model: 'test-model', api_key_env: 'OPENAI_API_KEY', dimensions: 3 },
+      qdrant: { mode: 'embedded', embedded_path: './qdrant', external_url: null, api_key_env: null },
+      transport: {
+        http: { enabled: true, host: '127.0.0.1', port: 3721, bearer_token_env: 'BHGBRAIN_TOKEN' },
+        stdio: { enabled: true },
+      },
+      defaults: {
+        namespace: 'global',
+        collection: 'general',
+        recall_limit: 5,
+        min_score: 0.6,
+        auto_inject_limit: 10,
+        max_response_chars: 50000,
+      },
+      retention: {
+        decay_after_days: 180,
+        max_db_size_gb: 2,
+        max_memories: 500000,
+        warn_at_percent: 80,
+        tier_ttl: { T0: null, T1: 365, T2: 90, T3: 30 },
+        tier_budgets: { T0: null, T1: 100000, T2: 200000, T3: 200000 },
+        auto_promote_access_threshold: 5,
+        sliding_window_enabled: true,
+        archive_before_delete: true,
+        cleanup_schedule: '0 2 * * *',
+        pre_expiry_warning_days: 7,
+        compaction_deleted_threshold: 0.1,
+      },
+      deduplication: { enabled: true, similarity_threshold: 0.92 },
+      resilience: {
+        circuit_breaker: {
+          failure_threshold: 1,
+          open_window_ms: 30000,
+          half_open_probe_count: 1,
+        },
+      },
+      search: { hybrid_weights: { semantic: 0.7, fulltext: 0.3 } },
+      security: {
+        require_loopback_http: true,
+        allow_unauthenticated_http: false,
+        log_redaction: true,
+        rate_limit_rpm: 100,
+        max_request_size_bytes: 1048576,
+      },
+      auto_inject: { max_chars: 30000, max_tokens: null },
+      observability: { metrics_enabled: false, structured_logging: true, log_level: 'info' },
+      pipeline: {
+        extraction_enabled: true,
+        extraction_model: 'gpt-4o-mini',
+        extraction_model_env: 'BHGBRAIN_EXTRACTION_API_KEY',
+        fallback_to_threshold_dedup: true,
+      },
+      auto_summarize: true,
+    };
+  }
+
+  function createStorage(): StorageManager {
+    return {
       sqlite: {
         healthCheck: vi.fn(() => true),
         countMemories: vi.fn(() => 42),
         getDbSizeBytes: vi.fn(() => 1024),
+        countByTier: vi.fn(() => ({ T0: 0, T1: 0, T2: 0, T3: 0 })),
+        countExpiringMemories: vi.fn(() => 0),
+        countArchivedMemories: vi.fn(() => 0),
+        countUnsyncedVectors: vi.fn(() => 0),
       },
       qdrant: {
         healthCheck: vi.fn(async () => true),
       },
-    } as any;
+    } as unknown as StorageManager;
+  }
 
-    let embedding: any;
-    if (degraded) {
-      embedding = {
-        model: 'test',
-        dimensions: 3,
-        degraded: true,
-        embed: vi.fn(async () => { throw new Error('unavailable'); }),
-        embedBatch: vi.fn(async () => { throw new Error('unavailable'); }),
-        healthCheck: vi.fn(async () => false),
-      };
-    } else {
-      embedding = {
-        model: 'test',
-        dimensions: 3,
-        embed: vi.fn(async () => [1, 2, 3]),
-        embedBatch: vi.fn(async () => [[1, 2, 3]]),
-        healthCheck: vi.fn(async () => embeddingOk),
-      };
-    }
-
-    return { storage, embedding };
+  function createEmbedding(embeddingOk = true): EmbeddingProvider {
+    return {
+      model: 'test',
+      dimensions: 3,
+      embed: vi.fn(async () => [1, 2, 3]),
+      embedBatch: vi.fn(async () => [[1, 2, 3]]),
+      healthCheck: vi.fn(async () => embeddingOk),
+    };
   }
 
   it('reports degraded when embedding provider is in degraded mode', async () => {
-    const { storage, embedding } = createMocks(false, true);
-    const health = new HealthService(storage, embedding);
+    const storage = createStorage();
+    const embedding = new DegradedEmbeddingProvider(createConfig());
+    const health = new HealthService(storage, embedding, createConfig());
     const result = await health.check();
     expect(result.status).toBe('degraded');
     expect(result.components.embedding.status).toBe('degraded');
-    // Should NOT call healthCheck API
-    expect(embedding.healthCheck).not.toHaveBeenCalled();
+  });
+
+  it('reports degraded when any breaker is open', async () => {
+    const storage = createStorage();
+    const embedding = createEmbedding(true);
+    const config = createConfig();
+    const breaker = new CircuitBreaker(
+      { failureThreshold: 1, openWindowMs: 30000, halfOpenProbeCount: 1 },
+      () => 0,
+    );
+
+    await expect(breaker.execute(async () => {
+      throw new Error('trip');
+    })).rejects.toThrow('trip');
+
+    const health = new HealthService(storage, embedding, config, {
+      openai_embedding: breaker,
+    });
+    const result = await health.check();
+
+    expect(result.status).toBe('degraded');
+    expect(result.circuitBreakers).toEqual({ openai_embedding: 'open' });
   });
 
   it('reports healthy when all components are up', async () => {
-    const { storage, embedding } = createMocks(true);
-    const health = new HealthService(storage, embedding);
+    const storage = createStorage();
+    const embedding = createEmbedding(true);
+    const health = new HealthService(storage, embedding, createConfig());
     const result = await health.check();
     expect(result.status).toBe('healthy');
   });
 
   it('caches embedding health check result', async () => {
-    const { storage, embedding } = createMocks(true);
-    const health = new HealthService(storage, embedding);
+    const storage = createStorage();
+    const embedding = createEmbedding(true);
+    const health = new HealthService(storage, embedding, createConfig());
 
     await health.check();
     await health.check();
     await health.check();
 
-    // Only one real healthCheck call despite 3 probes
     expect(embedding.healthCheck).toHaveBeenCalledTimes(1);
   });
 
   it('returns memory count and db size', async () => {
-    const { storage, embedding } = createMocks(true);
-    const health = new HealthService(storage, embedding);
+    const storage = createStorage();
+    const embedding = createEmbedding(true);
+    const health = new HealthService(storage, embedding, createConfig());
     const result = await health.check();
     expect(result.memory_count).toBe(42);
     expect(result.db_size_bytes).toBe(1024);
+  });
+
+  it('reports degraded when qdrant is unavailable but sqlite is healthy', async () => {
+    const storage = createStorage();
+    storage.qdrant.healthCheck = vi.fn(async () => false);
+
+    const health = new HealthService(storage, createEmbedding(true), createConfig());
+    const result = await health.check();
+
+    expect(result.status).toBe('degraded');
+    expect(result.components.qdrant.status).toBe('unhealthy');
+  });
+
+  it('reports unhealthy when sqlite is unavailable', async () => {
+    const storage = createStorage();
+    storage.sqlite.healthCheck = vi.fn(() => false);
+
+    const health = new HealthService(storage, createEmbedding(true), createConfig());
+    const result = await health.check();
+
+    expect(result.status).toBe('unhealthy');
+    expect(result.components.sqlite.status).toBe('unhealthy');
   });
 });

--- a/src/health/index.test.ts
+++ b/src/health/index.test.ts
@@ -76,6 +76,7 @@ describe('HealthService', () => {
         countExpiringMemories: vi.fn(() => 0),
         countArchivedMemories: vi.fn(() => 0),
         countUnsyncedVectors: vi.fn(() => 0),
+        getLifecycleOperation: vi.fn(() => null),
       },
       qdrant: {
         healthCheck: vi.fn(async () => true),
@@ -130,6 +131,11 @@ describe('HealthService', () => {
     const health = new HealthService(storage, embedding, createConfig());
     const result = await health.check();
     expect(result.status).toBe('healthy');
+    expect(result.components.vector_reconciliation).toEqual({
+      status: 'healthy',
+      state: 'reconciled',
+      unsynced_vectors: 0,
+    });
   });
 
   it('caches embedding health check result', async () => {
@@ -173,5 +179,38 @@ describe('HealthService', () => {
 
     expect(result.status).toBe('unhealthy');
     expect(result.components.sqlite.status).toBe('unhealthy');
+  });
+
+  it('reports degraded when vectors still need reconciliation after restore', async () => {
+    const storage = createStorage();
+    storage.sqlite.countUnsyncedVectors = vi.fn(() => 3);
+
+    const health = new HealthService(storage, createEmbedding(true), createConfig());
+    const result = await health.check();
+
+    expect(result.status).toBe('degraded');
+    expect(result.components.vector_reconciliation).toEqual({
+      status: 'degraded',
+      state: 'pending',
+      unsynced_vectors: 3,
+      message: 'SQLite metadata is active, but vector reconciliation is still required.',
+    });
+  });
+
+  it('reports reconciling while restore lifecycle work is active', async () => {
+    const storage = createStorage();
+    storage.sqlite.getLifecycleOperation = vi.fn(() => 'restore');
+    storage.sqlite.countUnsyncedVectors = vi.fn(() => 2);
+
+    const health = new HealthService(storage, createEmbedding(true), createConfig());
+    const result = await health.check();
+
+    expect(result.status).toBe('degraded');
+    expect(result.components.vector_reconciliation).toEqual({
+      status: 'degraded',
+      state: 'reconciling',
+      unsynced_vectors: 2,
+      message: 'Restore is active and vector reconciliation is in progress.',
+    });
   });
 });

--- a/src/health/index.ts
+++ b/src/health/index.ts
@@ -1,8 +1,9 @@
 import type { BrainConfig } from '../config/index.js';
 import type { HealthSnapshot, HealthStatus, ComponentHealth } from '../domain/types.js';
 import type { StorageManager } from '../storage/index.js';
-import type { EmbeddingProvider, DegradedEmbeddingProvider } from '../embedding/index.js';
+import { DegradedEmbeddingProvider, type EmbeddingProvider } from '../embedding/index.js';
 import type { RetentionTier } from '../domain/types.js';
+import type { CircuitBreaker } from '../resilience/index.js';
 
 const startTime = Date.now();
 
@@ -15,6 +16,7 @@ export class HealthService {
     private storage: StorageManager,
     private embedding: EmbeddingProvider,
     private config: BrainConfig,
+    private breakers: Record<string, CircuitBreaker> = {},
   ) {}
 
   async check(): Promise<HealthSnapshot> {
@@ -26,9 +28,7 @@ export class HealthService {
     const retentionOk = this.checkRetention();
 
     const overall = this.computeOverall(sqliteOk, qdrantOk, embeddingOk, retentionOk);
-    const countsByTier = typeof (this.storage.sqlite as any).countByTier === 'function'
-      ? this.storage.sqlite.countByTier()
-      : { T0: 0, T1: 0, T2: 0, T3: 0 };
+    const countsByTier = this.storage.sqlite.countByTier();
     const now = new Date();
     const until = new Date(now.getTime() + (7 * 24 * 60 * 60 * 1000));
 
@@ -43,17 +43,12 @@ export class HealthService {
       memory_count: this.storage.sqlite.countMemories(),
       db_size_bytes: this.storage.sqlite.getDbSizeBytes(),
       uptime_seconds: Math.floor((Date.now() - startTime) / 1000),
+      circuitBreakers: this.getCircuitBreakerStates(),
       retention: {
         counts_by_tier: countsByTier,
-        expiring_soon: typeof (this.storage.sqlite as any).countExpiringMemories === 'function'
-          ? this.storage.sqlite.countExpiringMemories(now.toISOString(), until.toISOString())
-          : 0,
-        archived_count: typeof (this.storage.sqlite as any).countArchivedMemories === 'function'
-          ? this.storage.sqlite.countArchivedMemories()
-          : 0,
-        unsynced_vectors: typeof (this.storage.sqlite as any).countUnsyncedVectors === 'function'
-          ? this.storage.sqlite.countUnsyncedVectors()
-          : 0,
+        expiring_soon: this.storage.sqlite.countExpiringMemories(now.toISOString(), until.toISOString()),
+        archived_count: this.storage.sqlite.countArchivedMemories(),
+        unsynced_vectors: this.storage.sqlite.countUnsyncedVectors(),
         over_capacity: this.isOverCapacity(countsByTier),
       },
     };
@@ -83,7 +78,7 @@ export class HealthService {
 
   private async checkEmbedding(): Promise<ComponentHealth> {
     // If running in degraded mode, skip the API call entirely
-    if ('degraded' in this.embedding && (this.embedding as DegradedEmbeddingProvider).degraded) {
+    if (this.embedding instanceof DegradedEmbeddingProvider) {
       return { status: 'degraded', message: 'Embedding provider unavailable (missing credentials)' };
     }
 
@@ -106,14 +101,11 @@ export class HealthService {
   }
 
   private checkRetention(): ComponentHealth {
-    if (typeof (this.storage.sqlite as any).countByTier !== 'function') {
-      return { status: 'healthy' };
-    }
     const counts = this.storage.sqlite.countByTier();
     if (this.isOverCapacity(counts)) {
       return { status: 'degraded', message: 'Retention tier or total capacity threshold exceeded' };
     }
-    if (typeof (this.storage.sqlite as any).countUnsyncedVectors === 'function' && this.storage.sqlite.countUnsyncedVectors() > 0) {
+    if (this.storage.sqlite.countUnsyncedVectors() > 0) {
       return { status: 'degraded', message: 'SQLite and Qdrant lifecycle state are out of sync' };
     }
     return { status: 'healthy' };
@@ -125,14 +117,16 @@ export class HealthService {
     embedding: ComponentHealth,
     retention: ComponentHealth,
   ): HealthStatus {
-    if (sqlite.status === 'unhealthy' || qdrant.status === 'unhealthy') {
+    if (sqlite.status === 'unhealthy') {
       return 'unhealthy';
     }
     if (
+      qdrant.status === 'unhealthy' ||
       embedding.status === 'degraded' ||
       embedding.status === 'unhealthy' ||
       retention.status === 'degraded' ||
-      retention.status === 'unhealthy'
+      retention.status === 'unhealthy' ||
+      Object.values(this.breakers).some(breaker => breaker.getState() === 'open')
     ) {
       return 'degraded';
     }
@@ -154,5 +148,11 @@ export class HealthService {
     }
 
     return false;
+  }
+
+  private getCircuitBreakerStates(): Record<string, 'closed' | 'open' | 'half-open'> {
+    return Object.fromEntries(
+      Object.entries(this.breakers).map(([name, breaker]) => [name, breaker.getState()]),
+    );
   }
 }

--- a/src/health/index.ts
+++ b/src/health/index.ts
@@ -1,5 +1,5 @@
 import type { BrainConfig } from '../config/index.js';
-import type { HealthSnapshot, HealthStatus, ComponentHealth } from '../domain/types.js';
+import type { HealthSnapshot, HealthStatus, ComponentHealth, VectorReconciliationStatus } from '../domain/types.js';
 import type { StorageManager } from '../storage/index.js';
 import { DegradedEmbeddingProvider, type EmbeddingProvider } from '../embedding/index.js';
 import type { RetentionTier } from '../domain/types.js';
@@ -26,8 +26,9 @@ export class HealthService {
       this.checkEmbedding(),
     ]);
     const retentionOk = this.checkRetention();
+    const vectorReconciliation = this.checkVectorReconciliation();
 
-    const overall = this.computeOverall(sqliteOk, qdrantOk, embeddingOk, retentionOk);
+    const overall = this.computeOverall(sqliteOk, qdrantOk, embeddingOk, vectorReconciliation, retentionOk);
     const countsByTier = this.storage.sqlite.countByTier();
     const now = new Date();
     const until = new Date(now.getTime() + (7 * 24 * 60 * 60 * 1000));
@@ -38,6 +39,7 @@ export class HealthService {
         sqlite: sqliteOk,
         qdrant: qdrantOk,
         embedding: embeddingOk,
+        vector_reconciliation: vectorReconciliation,
         retention: retentionOk,
       },
       memory_count: this.storage.sqlite.countMemories(),
@@ -105,16 +107,43 @@ export class HealthService {
     if (this.isOverCapacity(counts)) {
       return { status: 'degraded', message: 'Retention tier or total capacity threshold exceeded' };
     }
-    if (this.storage.sqlite.countUnsyncedVectors() > 0) {
-      return { status: 'degraded', message: 'SQLite and Qdrant lifecycle state are out of sync' };
-    }
     return { status: 'healthy' };
+  }
+
+  private checkVectorReconciliation(): VectorReconciliationStatus {
+    const unsyncedVectors = this.storage.sqlite.countUnsyncedVectors();
+    const lifecycleOperation = this.storage.sqlite.getLifecycleOperation();
+
+    if (lifecycleOperation === 'restore') {
+      return {
+        status: 'degraded',
+        state: 'reconciling',
+        unsynced_vectors: unsyncedVectors,
+        message: 'Restore is active and vector reconciliation is in progress.',
+      };
+    }
+
+    if (unsyncedVectors > 0) {
+      return {
+        status: 'degraded',
+        state: 'pending',
+        unsynced_vectors: unsyncedVectors,
+        message: 'SQLite metadata is active, but vector reconciliation is still required.',
+      };
+    }
+
+    return {
+      status: 'healthy',
+      state: 'reconciled',
+      unsynced_vectors: 0,
+    };
   }
 
   private computeOverall(
     sqlite: ComponentHealth,
     qdrant: ComponentHealth,
     embedding: ComponentHealth,
+    vectorReconciliation: VectorReconciliationStatus,
     retention: ComponentHealth,
   ): HealthStatus {
     if (sqlite.status === 'unhealthy') {
@@ -124,6 +153,8 @@ export class HealthService {
       qdrant.status === 'unhealthy' ||
       embedding.status === 'degraded' ||
       embedding.status === 'unhealthy' ||
+      vectorReconciliation.status === 'degraded' ||
+      vectorReconciliation.status === 'unhealthy' ||
       retention.status === 'degraded' ||
       retention.status === 'unhealthy' ||
       Object.values(this.breakers).some(breaker => breaker.getState() === 'open')

--- a/src/health/logger.test.ts
+++ b/src/health/logger.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrainConfig } from '../config/index.js';
+
+describe('logger helpers', () => {
+  function createConfig(logRedaction: boolean): BrainConfig {
+    return {
+      data_dir: 'test-data',
+      embedding: { provider: 'openai', model: 'test-model', api_key_env: 'OPENAI_API_KEY', dimensions: 3 },
+      qdrant: { mode: 'embedded', embedded_path: './qdrant', external_url: null, api_key_env: null },
+      transport: {
+        http: { enabled: true, host: '127.0.0.1', port: 3721, bearer_token_env: 'BHGBRAIN_TOKEN' },
+        stdio: { enabled: true },
+      },
+      defaults: {
+        namespace: 'global',
+        collection: 'general',
+        recall_limit: 5,
+        min_score: 0.6,
+        auto_inject_limit: 10,
+        max_response_chars: 50000,
+      },
+      retention: {
+        decay_after_days: 180,
+        max_db_size_gb: 2,
+        max_memories: 500000,
+        warn_at_percent: 80,
+        tier_ttl: { T0: null, T1: 365, T2: 90, T3: 30 },
+        tier_budgets: { T0: null, T1: 100000, T2: 200000, T3: 200000 },
+        auto_promote_access_threshold: 5,
+        sliding_window_enabled: true,
+        archive_before_delete: true,
+        cleanup_schedule: '0 2 * * *',
+        pre_expiry_warning_days: 7,
+        compaction_deleted_threshold: 0.1,
+      },
+      deduplication: { enabled: true, similarity_threshold: 0.92 },
+      resilience: {
+        circuit_breaker: {
+          failure_threshold: 1,
+          open_window_ms: 30000,
+          half_open_probe_count: 1,
+        },
+      },
+      search: { hybrid_weights: { semantic: 0.7, fulltext: 0.3 } },
+      security: {
+        require_loopback_http: true,
+        allow_unauthenticated_http: false,
+        log_redaction: logRedaction,
+        rate_limit_rpm: 100,
+        max_request_size_bytes: 1048576,
+      },
+      auto_inject: { max_chars: 30000, max_tokens: null },
+      observability: { metrics_enabled: false, structured_logging: true, log_level: 'warn' },
+      pipeline: {
+        extraction_enabled: true,
+        extraction_model: 'gpt-4o-mini',
+        extraction_model_env: 'BHGBRAIN_EXTRACTION_API_KEY',
+        fallback_to_threshold_dedup: true,
+      },
+      auto_summarize: true,
+    };
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('redacts long content and short/long tokens correctly', async () => {
+    const { redactContent, redactToken } = await import('./logger.js');
+    expect(redactContent('short content')).toBe('short content');
+    expect(redactContent('x'.repeat(60))).toBe(`${'x'.repeat(50)}...[redacted]`);
+    expect(redactToken('short')).toBe('***');
+    expect(redactToken('1234567890abcdef')).toBe('1234...cdef');
+  });
+
+  it('passes logger level and redact config to pino', async () => {
+    const pinoMock = vi.fn(() => ({ level: 'warn' }));
+    const stdTimeFunctions = { isoTime: vi.fn() };
+
+    vi.doMock('pino', () => ({
+      default: Object.assign(pinoMock, { stdTimeFunctions }),
+    }));
+
+    const { createLogger } = await import('./logger.js');
+    createLogger(createConfig(true));
+
+    expect(pinoMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'warn',
+        redact: expect.arrayContaining(['req.headers.authorization', 'token', 'bearer', 'api_key']),
+      }),
+      process.stdout,
+    );
+  });
+
+  it('omits redact config when redaction is disabled', async () => {
+    const pinoMock = vi.fn(() => ({ level: 'warn' }));
+    const stdTimeFunctions = { isoTime: vi.fn() };
+
+    vi.doMock('pino', () => ({
+      default: Object.assign(pinoMock, { stdTimeFunctions }),
+    }));
+
+    const { createLogger } = await import('./logger.js');
+    createLogger(createConfig(false));
+
+    expect(pinoMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'warn',
+        redact: undefined,
+      }),
+      process.stdout,
+    );
+  });
+});

--- a/src/health/logger.ts
+++ b/src/health/logger.ts
@@ -10,19 +10,22 @@ const REDACT_PATHS = [
 
 const CONTENT_PREVIEW_MAX = 50;
 
-export function createLogger(config: BrainConfig): pino.Logger {
+export function createLogger(config: BrainConfig, destination?: NodeJS.WritableStream): pino.Logger {
   const level = config.observability.log_level;
 
-  const logger = pino({
-    level,
-    formatters: {
-      level(label) {
-        return { level: label };
+  const logger = pino(
+    {
+      level,
+      formatters: {
+        level(label) {
+          return { level: label };
+        },
       },
+      timestamp: pino.stdTimeFunctions.isoTime,
+      redact: config.security.log_redaction ? REDACT_PATHS : undefined,
     },
-    timestamp: pino.stdTimeFunctions.isoTime,
-    redact: config.security.log_redaction ? REDACT_PATHS : undefined,
-  });
+    destination ?? process.stdout,
+  );
 
   return logger;
 }

--- a/src/health/metrics.test.ts
+++ b/src/health/metrics.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { MetricsCollector, computePercentile } from './metrics.js';
+import type { BrainConfig } from '../config/index.js';
+
+describe('MetricsCollector', () => {
+  function createConfig(metricsEnabled = true): BrainConfig {
+    return {
+      data_dir: 'test-data',
+      embedding: { provider: 'openai', model: 'test-model', api_key_env: 'OPENAI_API_KEY', dimensions: 3 },
+      qdrant: { mode: 'embedded', embedded_path: './qdrant', external_url: null, api_key_env: null },
+      transport: {
+        http: { enabled: true, host: '127.0.0.1', port: 3721, bearer_token_env: 'BHGBRAIN_TOKEN' },
+        stdio: { enabled: true },
+      },
+      defaults: {
+        namespace: 'global',
+        collection: 'general',
+        recall_limit: 5,
+        min_score: 0.6,
+        auto_inject_limit: 10,
+        max_response_chars: 50000,
+      },
+      retention: {
+        decay_after_days: 180,
+        max_db_size_gb: 2,
+        max_memories: 500000,
+        warn_at_percent: 80,
+        tier_ttl: { T0: null, T1: 365, T2: 90, T3: 30 },
+        tier_budgets: { T0: null, T1: 100000, T2: 200000, T3: 200000 },
+        auto_promote_access_threshold: 5,
+        sliding_window_enabled: true,
+        archive_before_delete: true,
+        cleanup_schedule: '0 2 * * *',
+        pre_expiry_warning_days: 7,
+        compaction_deleted_threshold: 0.1,
+      },
+      deduplication: { enabled: true, similarity_threshold: 0.92 },
+      resilience: {
+        circuit_breaker: {
+          failure_threshold: 1,
+          open_window_ms: 30000,
+          half_open_probe_count: 1,
+        },
+      },
+      search: { hybrid_weights: { semantic: 0.7, fulltext: 0.3 } },
+      security: {
+        require_loopback_http: true,
+        allow_unauthenticated_http: false,
+        log_redaction: true,
+        rate_limit_rpm: 100,
+        max_request_size_bytes: 1048576,
+      },
+      auto_inject: { max_chars: 30000, max_tokens: null },
+      observability: { metrics_enabled: metricsEnabled, structured_logging: true, log_level: 'info' },
+      pipeline: {
+        extraction_enabled: true,
+        extraction_model: 'gpt-4o-mini',
+        extraction_model_env: 'BHGBRAIN_EXTRACTION_API_KEY',
+        fallback_to_threshold_dedup: true,
+      },
+      auto_summarize: true,
+    };
+  }
+
+  it('emits histogram avg/count and percentile entries', () => {
+    const metrics = new MetricsCollector(createConfig());
+    metrics.recordHistogram('latency_ms', 10);
+    metrics.recordHistogram('latency_ms', 20);
+    metrics.recordHistogram('latency_ms', 30);
+    metrics.recordHistogram('latency_ms', 40);
+
+    const entries = Object.fromEntries(metrics.getMetrics().map(entry => [entry.name, entry.value]));
+
+    expect(entries.latency_ms_avg).toBe(25);
+    expect(entries.latency_ms_p50).toBe(20);
+    expect(entries.latency_ms_p95).toBe(40);
+    expect(entries.latency_ms_p99).toBe(40);
+    expect(entries.latency_ms_count).toBe(4);
+  });
+
+  it('computes percentiles for empty, single-value, and known distributions', () => {
+    expect(computePercentile([], 50)).toBe(0);
+    expect(computePercentile([7], 95)).toBe(7);
+
+    const values = Array.from({ length: 100 }, (_, index) => index + 1);
+    expect(computePercentile(values, 50)).toBe(50);
+    expect(computePercentile(values, 95)).toBe(95);
+    expect(computePercentile(values, 99)).toBe(99);
+  });
+
+  it('computes percentiles from the most recent 1000 histogram samples', () => {
+    const metrics = new MetricsCollector(createConfig());
+    for (let value = 1; value <= 1005; value += 1) {
+      metrics.recordHistogram('rolling_ms', value);
+    }
+
+    const entries = Object.fromEntries(metrics.getMetrics().map(entry => [entry.name, entry.value]));
+    expect(entries.rolling_ms_count).toBe(1000);
+    expect(entries.rolling_ms_p50).toBe(505);
+    expect(entries.rolling_ms_p95).toBe(955);
+    expect(entries.rolling_ms_p99).toBe(995);
+  });
+});

--- a/src/health/metrics.ts
+++ b/src/health/metrics.ts
@@ -7,6 +7,16 @@ interface MetricEntry {
   labels?: Record<string, string>;
 }
 
+export function computePercentile(sortedValues: number[], p: number): number {
+  if (sortedValues.length === 0) {
+    return 0;
+  }
+
+  const rank = Math.ceil((p / 100) * sortedValues.length);
+  const index = Math.min(sortedValues.length - 1, Math.max(0, rank - 1));
+  return sortedValues[index] ?? 0;
+}
+
 /** Bounded circular buffer for histogram values */
 class BoundedBuffer {
   private buffer: number[];
@@ -79,7 +89,11 @@ export class MetricsCollector {
       const count = vals.length;
       const sum = count > 0 ? vals.reduce((a, b) => a + b, 0) : 0;
       const avg = count > 0 ? sum / count : 0;
+      const sortedValues = [...vals].sort((a, b) => a - b);
       entries.push({ name: `${name}_avg`, type: 'histogram', value: avg });
+      entries.push({ name: `${name}_p50`, type: 'histogram', value: computePercentile(sortedValues, 50) });
+      entries.push({ name: `${name}_p95`, type: 'histogram', value: computePercentile(sortedValues, 95) });
+      entries.push({ name: `${name}_p99`, type: 'histogram', value: computePercentile(sortedValues, 99) });
       entries.push({ name: `${name}_count`, type: 'counter', value: count });
     }
     for (const [name, value] of this.gauges) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,10 +21,15 @@ import { BackupService } from './backup/index.js';
 import { HealthService } from './health/index.js';
 import { MetricsCollector } from './health/metrics.js';
 import { createLogger } from './health/logger.js';
+import { CircuitBreaker } from './resilience/index.js';
 import { ResourceHandler, MCP_RESOURCE_DEFINITIONS, MCP_RESOURCE_TEMPLATES } from './resources/index.js';
 import { handleTool, type ToolContext } from './tools/index.js';
 import { MCP_TOOL_DEFINITIONS } from './tools/schemas.js';
 import { createHttpServer } from './transport/http.js';
+
+function isErrorEnvelope(value: unknown): value is { error: unknown } {
+  return value != null && typeof value === 'object' && 'error' in value;
+}
 
 async function main() {
   const args = process.argv.slice(2);
@@ -42,16 +47,26 @@ async function main() {
   const sqlite = new SqliteStore(config.data_dir!);
   await sqlite.init();
 
+  const breakerOptions = {
+    failureThreshold: config.resilience.circuit_breaker.failure_threshold,
+    openWindowMs: config.resilience.circuit_breaker.open_window_ms,
+    halfOpenProbeCount: config.resilience.circuit_breaker.half_open_probe_count,
+  };
+  const embeddingBreaker = new CircuitBreaker(breakerOptions);
+  const qdrantBreaker = new CircuitBreaker(breakerOptions);
   const metrics = new MetricsCollector(config);
-  const qdrant = new QdrantStore(config);
-  const embedding = createEmbeddingProvider(config, { metrics });
+  const qdrant = new QdrantStore(config, qdrantBreaker);
+  const embedding = createEmbeddingProvider(config, { breaker: embeddingBreaker, metrics });
   const storage = new StorageManager(sqlite, qdrant, embedding);
 
   // Initialize services
   const pipeline = new WritePipeline(config, storage, embedding);
   const searchService = new SearchService(config, storage, embedding, metrics);
   const backupService = new BackupService(config, storage, logger);
-  const healthService = new HealthService(storage, embedding, config);
+  const healthService = new HealthService(storage, embedding, config, {
+    openai_embedding: embeddingBreaker,
+    qdrant: qdrantBreaker,
+  });
 
   const ctx: ToolContext = {
     config, storage, embedding, pipeline,
@@ -77,7 +92,7 @@ async function main() {
       const result = await handleTool(ctx, name, toolArgs);
 
       // Detect error envelopes and signal via MCP isError
-      const isError = result != null && typeof result === 'object' && 'error' in (result as any);
+      const isError = isErrorEnvelope(result);
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         ...(isError ? { isError: true } : {}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,8 @@ async function main() {
   const config = loadConfig(configPath);
   ensureDataDir(config);
 
-  const logger = createLogger(config);
+  // When using stdio transport, pino must write to stderr — stdout is reserved for MCP JSON-RPC
+  const logger = createLogger(config, isStdio ? process.stderr : undefined);
   logger.info({ event: 'startup', data_dir: config.data_dir });
 
   // Initialize storage

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,16 +42,16 @@ async function main() {
   const sqlite = new SqliteStore(config.data_dir!);
   await sqlite.init();
 
+  const metrics = new MetricsCollector(config);
   const qdrant = new QdrantStore(config);
-  const embedding = createEmbeddingProvider(config);
+  const embedding = createEmbeddingProvider(config, { metrics });
   const storage = new StorageManager(sqlite, qdrant, embedding);
 
   // Initialize services
   const pipeline = new WritePipeline(config, storage, embedding);
-  const searchService = new SearchService(config, storage, embedding);
+  const searchService = new SearchService(config, storage, embedding, metrics);
   const backupService = new BackupService(config, storage, logger);
   const healthService = new HealthService(storage, embedding, config);
-  const metrics = new MetricsCollector(config);
 
   const ctx: ToolContext = {
     config, storage, embedding, pipeline,

--- a/src/pipeline/index.test.ts
+++ b/src/pipeline/index.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { WritePipeline } from './index.js';
 import type { BrainConfig } from '../config/index.js';
+import type { EmbeddingProvider } from '../embedding/index.js';
+import type { StorageManager } from '../storage/index.js';
 
 describe('WritePipeline NOOP handling', () => {
   const config = {
@@ -8,11 +10,15 @@ describe('WritePipeline NOOP handling', () => {
     pipeline: { extraction_enabled: true, fallback_to_threshold_dedup: true },
   } as unknown as BrainConfig;
 
-  const embedding = {
+  const embedding: EmbeddingProvider = {
+    model: 'test-model',
+    dimensions: 2,
     embed: vi.fn(async () => [0.1, 0.2]),
-  } as any;
+    embedBatch: vi.fn(async (texts: string[]) => texts.map(() => [0.1, 0.2])),
+    healthCheck: vi.fn(async () => true),
+  };
 
-  let storage: any;
+  let storage: StorageManager;
 
   beforeEach(() => {
     storage = {
@@ -36,7 +42,7 @@ describe('WritePipeline NOOP handling', () => {
       writeMemory: vi.fn(),
       writeMemoryWithoutVector: vi.fn(),
       logAudit: vi.fn(),
-    };
+    } as unknown as StorageManager;
   });
 
   it('returns NOOP without writes when classification is NOOP', async () => {

--- a/src/resilience/circuit-breaker.test.ts
+++ b/src/resilience/circuit-breaker.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { CircuitBreaker, CircuitOpenError } from './circuit-breaker.js';
+
+describe('CircuitBreaker', () => {
+  it('transitions closed to open and fast-fails while open', async () => {
+    let now = 0;
+    const breaker = new CircuitBreaker(
+      { failureThreshold: 2, openWindowMs: 1_000, halfOpenProbeCount: 1 },
+      () => now,
+    );
+
+    await expect(breaker.execute(async () => {
+      throw new Error('fail-1');
+    })).rejects.toThrow('fail-1');
+
+    await expect(breaker.execute(async () => {
+      throw new Error('fail-2');
+    })).rejects.toThrow('fail-2');
+
+    expect(breaker.getState()).toBe('open');
+    await expect(breaker.execute(async () => 'ok')).rejects.toBeInstanceOf(CircuitOpenError);
+
+    now = 1_001;
+    expect(breaker.getState()).toBe('half-open');
+  });
+
+  it('closes after enough successful half-open probes', async () => {
+    let now = 0;
+    const breaker = new CircuitBreaker(
+      { failureThreshold: 1, openWindowMs: 100, halfOpenProbeCount: 2 },
+      () => now,
+    );
+
+    await expect(breaker.execute(async () => {
+      throw new Error('trip');
+    })).rejects.toThrow('trip');
+
+    now = 101;
+    await expect(breaker.execute(async () => 'probe-1')).resolves.toBe('probe-1');
+    expect(breaker.getState()).toBe('half-open');
+
+    await expect(breaker.execute(async () => 'probe-2')).resolves.toBe('probe-2');
+    expect(breaker.getState()).toBe('closed');
+    expect(breaker.getStats().failures).toBe(0);
+  });
+
+  it('reopens when a half-open probe fails', async () => {
+    let now = 0;
+    const breaker = new CircuitBreaker(
+      { failureThreshold: 1, openWindowMs: 100, halfOpenProbeCount: 1 },
+      () => now,
+    );
+
+    await expect(breaker.execute(async () => {
+      throw new Error('trip');
+    })).rejects.toThrow('trip');
+
+    now = 101;
+    await expect(breaker.execute(async () => {
+      throw new Error('probe-failed');
+    })).rejects.toThrow('probe-failed');
+
+    expect(breaker.getState()).toBe('open');
+  });
+});

--- a/src/resilience/circuit-breaker.ts
+++ b/src/resilience/circuit-breaker.ts
@@ -1,0 +1,103 @@
+export type CircuitBreakerState = 'closed' | 'open' | 'half-open';
+
+export interface CircuitBreakerOptions {
+  failureThreshold: number;
+  openWindowMs: number;
+  halfOpenProbeCount: number;
+}
+
+export class CircuitOpenError extends Error {
+  constructor(message = 'Circuit breaker is open') {
+    super(message);
+    this.name = 'CircuitOpenError';
+  }
+}
+
+export class CircuitBreaker {
+  private state: CircuitBreakerState = 'closed';
+  private failures = 0;
+  private lastOpenedAt: Date | null = null;
+  private halfOpenSuccesses = 0;
+
+  constructor(
+    private readonly options: CircuitBreakerOptions,
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    this.transitionToHalfOpenIfReady();
+
+    if (this.state === 'open') {
+      throw new CircuitOpenError();
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess();
+      return result;
+    } catch (error) {
+      this.onFailure();
+      throw error;
+    }
+  }
+
+  getState(): CircuitBreakerState {
+    this.transitionToHalfOpenIfReady();
+    return this.state;
+  }
+
+  getStats(): { failures: number; lastOpenedAt: Date | null } {
+    return {
+      failures: this.failures,
+      lastOpenedAt: this.lastOpenedAt,
+    };
+  }
+
+  private onSuccess(): void {
+    if (this.state === 'half-open') {
+      this.halfOpenSuccesses += 1;
+      if (this.halfOpenSuccesses >= this.options.halfOpenProbeCount) {
+        this.close();
+      }
+      return;
+    }
+
+    this.failures = 0;
+  }
+
+  private onFailure(): void {
+    if (this.state === 'half-open') {
+      this.open();
+      return;
+    }
+
+    this.failures += 1;
+    if (this.failures >= this.options.failureThreshold) {
+      this.open();
+    }
+  }
+
+  private transitionToHalfOpenIfReady(): void {
+    if (this.state !== 'open' || this.lastOpenedAt === null) {
+      return;
+    }
+
+    if ((this.now() - this.lastOpenedAt.getTime()) >= this.options.openWindowMs) {
+      this.state = 'half-open';
+      this.halfOpenSuccesses = 0;
+    }
+  }
+
+  private open(): void {
+    this.state = 'open';
+    this.failures = this.options.failureThreshold;
+    this.halfOpenSuccesses = 0;
+    this.lastOpenedAt = new Date(this.now());
+  }
+
+  private close(): void {
+    this.state = 'closed';
+    this.failures = 0;
+    this.halfOpenSuccesses = 0;
+  }
+}

--- a/src/resilience/index.ts
+++ b/src/resilience/index.ts
@@ -1,0 +1,1 @@
+export { CircuitBreaker, CircuitOpenError, type CircuitBreakerOptions, type CircuitBreakerState } from './circuit-breaker.js';

--- a/src/resources/index.test.ts
+++ b/src/resources/index.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { ResourceHandler, MCP_RESOURCE_DEFINITIONS, MCP_RESOURCE_TEMPLATES } from './index.js';
+import type { BrainConfig } from '../config/index.js';
+import type { HealthService } from '../health/index.js';
+import type { SearchService } from '../search/index.js';
+import type { StorageManager } from '../storage/index.js';
+import type { BrainErrorEnvelope, ErrorEnvelope } from '../errors/index.js';
+
+type ListResult = { items: unknown[]; total_results: number };
+type InjectResult = { content: string; truncated: boolean };
+type ResourceResult = ListResult | InjectResult | ErrorEnvelope;
 
 describe('resource pagination bounds', () => {
   function createHandler() {
@@ -34,57 +43,67 @@ describe('resource pagination bounds', () => {
         listCollections: () => [],
         getCategory: () => null,
       },
-    } as any;
+    } as unknown as StorageManager;
+
+    const config = {
+      defaults: { namespace: 'global', auto_inject_limit: 5 },
+      auto_inject: { max_chars: 500 },
+    } as unknown as BrainConfig;
 
     return new ResourceHandler(
-      { defaults: { namespace: 'global', auto_inject_limit: 5 }, auto_inject: { max_chars: 500 } } as any,
+      config,
       storage,
-      {} as any,
-      { check: async () => ({ status: 'healthy' }) } as any,
+      {} as SearchService,
+      { check: async () => ({ status: 'healthy' }) } as HealthService,
     );
   }
 
   it('returns INVALID_INPUT for non-numeric limit', async () => {
     const handler = createHandler();
-    const result = await handler.handle('memory://list?limit=abc') as any;
+    const result = await handler.handle('memory://list?limit=abc') as ResourceResult;
     expect(result.error.code).toBe('INVALID_INPUT');
   });
 
   it('returns INVALID_INPUT for out-of-range limit', async () => {
     const handler = createHandler();
-    const result = await handler.handle('memory://list?limit=1000') as any;
+    const result = await handler.handle('memory://list?limit=1000') as ResourceResult;
     expect(result.error.code).toBe('INVALID_INPUT');
   });
 
   it('returns bounded paginated response for valid limit', async () => {
     const handler = createHandler();
-    const result = await handler.handle('memory://list?limit=1') as any;
+    const result = await handler.handle('memory://list?limit=1') as ResourceResult;
     expect(result.items).toHaveLength(1);
     expect(result.total_results).toBe(2);
   });
 
   it('builds inject payload within budget without concatenating all category content', async () => {
+    const config = {
+      defaults: { namespace: 'global', auto_inject_limit: 5 },
+      auto_inject: { max_chars: 24 },
+    } as unknown as BrainConfig;
+    const storage = {
+      sqlite: {
+        listCategoryHeaders: () => [{ name: 'Policy', slot: 'custom', revision: 1, updated_at: '2026-01-01T00:00:00Z', content_length: 200 }],
+        getCategoryContentSlice: (_name: string, maxChars: number) => 'x'.repeat(maxChars),
+        listMemories: () => [],
+        countMemories: () => 0,
+        getMemoryById: () => null,
+        touchMemory: () => undefined,
+        scheduleDeferredFlush: () => undefined,
+        listCategories: () => [],
+        listCollections: () => [],
+        getCategory: () => null,
+      },
+    } as unknown as StorageManager;
     const handler = new ResourceHandler(
-      { defaults: { namespace: 'global', auto_inject_limit: 5 }, auto_inject: { max_chars: 24 } } as any,
-      {
-        sqlite: {
-          listCategoryHeaders: () => [{ name: 'Policy', slot: 'custom', revision: 1, updated_at: '2026-01-01T00:00:00Z', content_length: 200 }],
-          getCategoryContentSlice: (_name: string, maxChars: number) => 'x'.repeat(maxChars),
-          listMemories: () => [],
-          countMemories: () => 0,
-          getMemoryById: () => null,
-          touchMemory: () => undefined,
-          scheduleDeferredFlush: () => undefined,
-          listCategories: () => [],
-          listCollections: () => [],
-          getCategory: () => null,
-        },
-      } as any,
-      {} as any,
-      { check: async () => ({ status: 'healthy' }) } as any,
+      config,
+      storage,
+      {} as SearchService,
+      { check: async () => ({ status: 'healthy' }) } as HealthService,
     );
 
-    const result = await handler.handle('memory://inject') as any;
+    const result = await handler.handle('memory://inject') as ResourceResult;
     expect(result.content.length).toBeLessThanOrEqual(24);
     expect(result.truncated).toBe(true);
   });

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -3,6 +3,7 @@ import type { StorageManager } from '../storage/index.js';
 import type { SearchService } from '../search/index.js';
 import type { HealthService } from '../health/index.js';
 import type { InjectPayload, PaginatedResult, MemoryRecord } from '../domain/types.js';
+import type { CategoryHeader } from '../storage/sqlite.js';
 
 export class ResourceHandler {
   private static readonly LIST_LIMIT_MIN = 1;
@@ -139,16 +140,7 @@ export class ResourceHandler {
     };
 
     // 1. All category content (full)
-    const categoryHeaders = typeof (this.storage.sqlite as any).listCategoryHeaders === 'function'
-      ? this.storage.sqlite.listCategoryHeaders()
-      : this.storage.sqlite.listCategories().map((cat: any) => ({
-        name: cat.name,
-        slot: cat.slot,
-        revision: cat.revision,
-        updated_at: cat.updated_at,
-        content_length: cat.content.length,
-        content: cat.content,
-      }));
+    const categoryHeaders = this.storage.sqlite.listCategoryHeaders();
     let categoriesCount = 0;
     for (const cat of categoryHeaders) {
       if (totalChars >= maxChars) {
@@ -165,10 +157,8 @@ export class ResourceHandler {
         break;
       }
 
-      const content = 'content' in cat
-        ? cat.content.slice(0, remainingForContent)
-        : this.storage.sqlite.getCategoryContentSlice(cat.name, remainingForContent) ?? '';
-      const fullyIncluded = content.length >= (cat.content_length ?? content.length);
+      const content = this.storage.sqlite.getCategoryContentSlice(cat.name, remainingForContent) ?? '';
+      const fullyIncluded = content.length >= cat.content_length;
       if (!appendBlock(`${content}\n\n`)) break;
       if (!fullyIncluded) {
         truncated = true;

--- a/src/search/index.test.ts
+++ b/src/search/index.test.ts
@@ -1,16 +1,36 @@
 import { describe, it, expect, vi } from 'vitest';
 import { SearchService } from './index.js';
+import type { BrainConfig } from '../config/index.js';
+import type { EmbeddingProvider } from '../embedding/index.js';
+import type { MetricsCollector } from '../health/metrics.js';
+import type { MemoryRecord } from '../domain/types.js';
+import type { StorageManager } from '../storage/index.js';
+
+type StoredMemory = Omit<MemoryRecord, 'embedding'>;
 
 describe('SearchService', () => {
   function createSearchService(opts: {
     fulltextResults?: Array<{ id: string; rank: number }>;
-    memories?: Map<string, any>;
+    memories?: Map<string, StoredMemory>;
   } = {}) {
     const memories = opts.memories ?? new Map([
       ['mem-1', {
         id: 'mem-1', namespace: 'global', collection: 'general', type: 'semantic',
         content: 'hello world', summary: 'hello', tags: [], source: 'cli',
-        score: 0.9, created_at: '2026-01-01T00:00:00Z', last_accessed: '2026-01-01T00:00:00Z',
+        checksum: 'mem-1',
+        importance: 0.9,
+        retention_tier: 'T2',
+        expires_at: '2026-12-31T00:00:00Z',
+        decay_eligible: true,
+        review_due: null,
+        access_count: 0,
+        last_operation: 'ADD',
+        merged_from: null,
+        archived: false,
+        vector_synced: true,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        last_accessed: '2026-01-01T00:00:00Z',
       }],
     ]);
 
@@ -28,15 +48,19 @@ describe('SearchService', () => {
       qdrant: {
         search: vi.fn(async () => []),
       },
-    } as any;
+    } as unknown as StorageManager;
 
     const config = {
       search: { hybrid_weights: { semantic: 0.7, fulltext: 0.3 } },
-    } as any;
+    } as unknown as BrainConfig;
 
     const embedding = {
+      model: 'test-model',
+      dimensions: 3,
       embed: vi.fn(async () => [1, 2, 3]),
-    } as any;
+      embedBatch: vi.fn(async (texts: string[]) => texts.map(() => [1, 2, 3])),
+      healthCheck: vi.fn(async () => true),
+    } as EmbeddingProvider;
 
     return {
       service: new SearchService(config, storage, embedding),

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -2,6 +2,7 @@ import type { BrainConfig } from '../config/index.js';
 import type { StorageManager } from '../storage/index.js';
 import type { EmbeddingProvider } from '../embedding/index.js';
 import type { SearchMode, SearchResult } from '../domain/types.js';
+import type { MetricsCollector } from '../health/metrics.js';
 import { MemoryLifecycleService } from '../domain/lifecycle.js';
 import { embeddingUnavailable, internal } from '../errors/index.js';
 
@@ -22,6 +23,7 @@ export class SearchService {
     private config: BrainConfig,
     private storage: StorageManager,
     private embedding: EmbeddingProvider,
+    private metrics?: MetricsCollector,
   ) {
     this.lifecycle = new MemoryLifecycleService(config);
   }
@@ -33,13 +35,20 @@ export class SearchService {
     mode: SearchMode,
     limit: number,
   ): Promise<SearchResult[]> {
-    switch (mode) {
-      case 'semantic':
-        return this.semanticSearch(query, namespace, collection, limit);
-      case 'fulltext':
-        return this.fulltextSearch(query, namespace, collection, limit);
-      case 'hybrid':
-        return this.hybridSearch(query, namespace, collection, limit);
+    const start = Date.now();
+    try {
+      switch (mode) {
+        case 'semantic':
+          return await this.semanticSearch(query, namespace, collection, limit);
+        case 'fulltext':
+          return this.fulltextSearch(query, namespace, collection, limit);
+        case 'hybrid':
+          return await this.hybridSearch(query, namespace, collection, limit);
+      }
+      const unsupportedMode: never = mode;
+      throw new Error(`Unsupported search mode: ${unsupportedMode}`);
+    } finally {
+      this.metrics?.recordHistogram('search_total_ms', Date.now() - start);
     }
   }
 

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -1,7 +1,8 @@
 import type { BrainConfig } from '../config/index.js';
 import type { StorageManager } from '../storage/index.js';
 import type { EmbeddingProvider } from '../embedding/index.js';
-import type { SearchMode, SearchResult } from '../domain/types.js';
+import type { SearchMode, SearchResult, MemoryRecord } from '../domain/types.js';
+import type { AccessUpdate } from '../storage/sqlite.js';
 import type { MetricsCollector } from '../health/metrics.js';
 import { MemoryLifecycleService } from '../domain/lifecycle.js';
 import { embeddingUnavailable, internal } from '../errors/index.js';
@@ -169,32 +170,22 @@ export class SearchService {
     );
   }
 
+
   private buildSearchResults(
     ranked: Array<{ id: string; score: number; semantic_score?: number; fulltext_score?: number; qdrantPayload?: Record<string, unknown> }>,
     options?: { boostT0?: boolean },
   ): SearchResult[] {
     const now = new Date();
     const nowIso = now.toISOString();
-    const memories = typeof (this.storage.sqlite as any).getMemoriesByIds === 'function'
-      ? this.storage.sqlite.getMemoriesByIds(ranked.map(item => item.id))
-      : ranked
-        .map(item => this.storage.sqlite.getMemoryById(item.id))
-        .filter(Boolean);
-    const memoryMap = new Map(memories.map((mem: any) => [mem.id, mem]));
-    const accessUpdates: Array<{
-      id: string;
-      access_count: number;
-      last_accessed: string;
-      expires_at?: string | null;
-      retention_tier?: SearchResult['retention_tier'];
-      review_due?: string | null;
-    }> = [];
+    const memories = this.storage.sqlite.getMemoriesByIds(ranked.map(item => item.id));
+    const memoryMap = new Map(memories.map(mem => [mem.id, mem]));
+    const accessUpdates: AccessUpdate[] = [];
     const searchResults: SearchResult[] = [];
 
     for (const item of ranked) {
       const mem = memoryMap.get(item.id);
 
-      // Fallback to Qdrant payload if SQLite miss
+      // Fallback to Qdrant payload if SQLite miss (cross-device memory)
       if (!mem) {
         if (item.qdrantPayload && typeof item.qdrantPayload.content === 'string') {
           const payload = item.qdrantPayload;
@@ -245,24 +236,7 @@ export class SearchService {
     }
 
     if (accessUpdates.length > 0) {
-      if (typeof (this.storage.sqlite as any).recordAccessBatch === 'function') {
-        this.storage.sqlite.recordAccessBatch(accessUpdates);
-      } else if (typeof (this.storage.sqlite as any).recordAccess === 'function') {
-        for (const update of accessUpdates) {
-          this.storage.sqlite.recordAccess(
-            update.id,
-            update.access_count,
-            update.last_accessed,
-            update.expires_at,
-            update.retention_tier,
-            update.review_due,
-          );
-        }
-      } else {
-        for (const update of accessUpdates) {
-          this.storage.sqlite.touchMemory(update.id);
-        }
-      }
+      this.storage.sqlite.recordAccessBatch(accessUpdates);
       this.storage.sqlite.scheduleDeferredFlush();
     }
 
@@ -270,17 +244,10 @@ export class SearchService {
   }
 
   private buildAccessUpdate(
-    mem: { id: string; access_count: number; retention_tier: SearchResult['retention_tier']; expires_at: string | null },
+    mem: Pick<MemoryRecord, 'id' | 'access_count' | 'retention_tier' | 'expires_at'>,
     now: Date,
     nowIso: string,
-  ): {
-    id: string;
-    access_count: number;
-    last_accessed: string;
-    expires_at?: string | null;
-    retention_tier?: SearchResult['retention_tier'];
-    review_due?: string | null;
-  } {
+  ): AccessUpdate {
     const nextAccessCount = mem.access_count + 1;
     const promotedTier = this.lifecycle.shouldPromote(mem.retention_tier, nextAccessCount) ?? mem.retention_tier;
     const nextExpiry = this.lifecycle.extendExpiry(promotedTier, now);

--- a/src/storage/index.test.ts
+++ b/src/storage/index.test.ts
@@ -10,9 +10,11 @@ type MockSqliteStore = SqliteStore & {
   insertMemory: ReturnType<typeof vi.fn>;
   updateMemory: ReturnType<typeof vi.fn>;
   getCollection: ReturnType<typeof vi.fn>;
+  listMemoriesNeedingVectorSync: ReturnType<typeof vi.fn>;
 };
 type MockQdrantStore = QdrantStore & {
   upsert: ReturnType<typeof vi.fn>;
+  clearManagedCollections: ReturnType<typeof vi.fn>;
 };
 
 function createMockSqlite(): MockSqliteStore {
@@ -42,8 +44,16 @@ function createMockSqlite(): MockSqliteStore {
     getCollection: vi.fn(() => ({ name: 'general', namespace: 'global', embedding_model: 'test', embedding_dimensions: 3 })),
     createCollection: vi.fn(),
     listMemoryIdsInCollection: vi.fn(() => ['mem-1']),
+    listMemoriesNeedingVectorSync: vi.fn(() => []),
     flushIfDirty: vi.fn(),
     countMemories: vi.fn(() => memoryStore.size),
+    countUnsyncedVectors: vi.fn(() => Array.from(memoryStore.values()).filter(mem => !mem.vector_synced).length),
+    markAllVectorsSyncState: vi.fn((synced: boolean) => {
+      for (const memory of memoryStore.values()) {
+        memory.vector_synced = synced;
+      }
+      return memoryStore.size;
+    }),
   } as unknown as MockSqliteStore;
 }
 
@@ -55,6 +65,7 @@ function createMockQdrant(shouldFail = false): MockQdrantStore {
     delete: vi.fn(async () => {}),
     deleteMany: vi.fn(async () => {}),
     deleteCollection: vi.fn(async () => {}),
+    clearManagedCollections: vi.fn(async () => 0),
   } as unknown as MockQdrantStore;
 }
 
@@ -161,6 +172,36 @@ describe('StorageManager cross-store consistency', () => {
 
       expect(sqlite.createCollection).toHaveBeenCalledWith('global', 'general', 'test', 3);
       expect(sqlite.insertMemory).toHaveBeenCalledWith(expect.objectContaining({ vector_synced: false }));
+    });
+  });
+
+  describe('restore reconciliation helpers', () => {
+    it('rebuilds unsynced vectors from restored SQLite rows', async () => {
+      const sqlite = createMockSqlite();
+      const qdrant = createMockQdrant(false);
+      const embedding = createMockEmbedding();
+      const storage = new StorageManager(sqlite, qdrant, embedding);
+
+      sqlite.insertMemory({ ...baseMem, id: 'mem-a', vector_synced: false });
+      sqlite.insertMemory({ ...baseMem, id: 'mem-b', vector_synced: false, content: 'content-b', checksum: 'chk2' });
+      sqlite.listMemoriesNeedingVectorSync
+        .mockReturnValueOnce([
+          sqlite.getMemoryById('mem-a')!,
+          sqlite.getMemoryById('mem-b')!,
+        ])
+        .mockReturnValueOnce([]);
+
+      const result = await storage.reconcileVectorsFromSqlite({ batchSize: 2 });
+
+      expect(embedding.embedBatch).toHaveBeenCalledWith(['test content', 'content-b']);
+      expect(qdrant.upsert).toHaveBeenCalledTimes(2);
+      expect(sqlite.markVectorSync).toHaveBeenNthCalledWith(1, 'mem-a', true, {
+        allowDuringLifecycle: undefined,
+      });
+      expect(sqlite.markVectorSync).toHaveBeenNthCalledWith(2, 'mem-b', true, {
+        allowDuringLifecycle: undefined,
+      });
+      expect(result).toEqual({ reconciled: 2, remaining: 0 });
     });
   });
 });

--- a/src/storage/index.test.ts
+++ b/src/storage/index.test.ts
@@ -203,5 +203,40 @@ describe('StorageManager cross-store consistency', () => {
       });
       expect(result).toEqual({ reconciled: 2, remaining: 0 });
     });
+
+    it('flushes completed reconciliation progress before returning a later failure', async () => {
+      const sqlite = createMockSqlite();
+      const qdrant = createMockQdrant(false);
+      const embedding = createMockEmbedding();
+      const storage = new StorageManager(sqlite, qdrant, embedding);
+
+      sqlite.insertMemory({ ...baseMem, id: 'mem-a', vector_synced: false });
+      sqlite.insertMemory({ ...baseMem, id: 'mem-b', vector_synced: false, content: 'content-b', checksum: 'chk2' });
+      sqlite.listMemoriesNeedingVectorSync
+        .mockReturnValueOnce([
+          sqlite.getMemoryById('mem-a')!,
+          sqlite.getMemoryById('mem-b')!,
+        ])
+        .mockReturnValueOnce([
+          sqlite.getMemoryById('mem-b')!,
+        ])
+        .mockReturnValueOnce([]);
+
+      qdrant.upsert
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('Qdrant unavailable'))
+        .mockResolvedValueOnce(undefined);
+
+      await expect(storage.reconcileVectorsFromSqlite({ batchSize: 2 })).rejects.toThrow('Qdrant unavailable');
+      expect(sqlite.flushIfDirty).toHaveBeenCalledTimes(1);
+      expect(sqlite.getMemoryById('mem-a')?.vector_synced).toBe(true);
+      expect(sqlite.getMemoryById('mem-b')?.vector_synced).toBe(false);
+      expect(sqlite.countUnsyncedVectors()).toBe(1);
+
+      const retryResult = await storage.reconcileVectorsFromSqlite({ batchSize: 2 });
+
+      expect(retryResult).toEqual({ reconciled: 1, remaining: 0 });
+      expect(sqlite.getMemoryById('mem-b')?.vector_synced).toBe(true);
+    });
   });
 });

--- a/src/storage/index.test.ts
+++ b/src/storage/index.test.ts
@@ -3,18 +3,30 @@ import { StorageManager } from './index.js';
 import type { SqliteStore } from './sqlite.js';
 import type { QdrantStore } from './qdrant.js';
 import type { EmbeddingProvider } from '../embedding/index.js';
+import type { MemoryRecord } from '../domain/types.js';
 
-function createMockSqlite(): SqliteStore {
-  const memoryStore = new Map<string, any>();
+type StoredMemory = Omit<MemoryRecord, 'embedding'>;
+type MockSqliteStore = SqliteStore & {
+  insertMemory: ReturnType<typeof vi.fn>;
+  updateMemory: ReturnType<typeof vi.fn>;
+  getCollection: ReturnType<typeof vi.fn>;
+};
+type MockQdrantStore = QdrantStore & {
+  upsert: ReturnType<typeof vi.fn>;
+};
+
+function createMockSqlite(): MockSqliteStore {
+  const memoryStore = new Map<string, StoredMemory>();
 
   return {
     getMemoryById: vi.fn((id: string) => memoryStore.get(id) ?? null),
-    insertMemory: vi.fn((mem: any) => { memoryStore.set(mem.id, { ...mem }); }),
-    updateMemory: vi.fn((id: string, fields: any) => {
+    insertMemory: vi.fn((mem: StoredMemory) => { memoryStore.set(mem.id, { ...mem }); }),
+    updateMemory: vi.fn((id: string, fields: Partial<StoredMemory>) => {
       const existing = memoryStore.get(id);
       if (existing) {
         for (const [k, v] of Object.entries(fields)) {
-          existing[k] = v;
+          const key = k as keyof StoredMemory;
+          existing[key] = v as StoredMemory[typeof key];
         }
       }
     }),
@@ -32,10 +44,10 @@ function createMockSqlite(): SqliteStore {
     listMemoryIdsInCollection: vi.fn(() => ['mem-1']),
     flushIfDirty: vi.fn(),
     countMemories: vi.fn(() => memoryStore.size),
-  } as unknown as SqliteStore;
+  } as unknown as MockSqliteStore;
 }
 
-function createMockQdrant(shouldFail = false): QdrantStore {
+function createMockQdrant(shouldFail = false): MockQdrantStore {
   return {
     upsert: shouldFail
       ? vi.fn(async () => { throw new Error('Qdrant unavailable'); })
@@ -43,7 +55,7 @@ function createMockQdrant(shouldFail = false): QdrantStore {
     delete: vi.fn(async () => {}),
     deleteMany: vi.fn(async () => {}),
     deleteCollection: vi.fn(async () => {}),
-  } as unknown as QdrantStore;
+  } as unknown as MockQdrantStore;
 }
 
 function createMockEmbedding(): EmbeddingProvider {
@@ -107,7 +119,7 @@ describe('StorageManager cross-store consistency', () => {
       await storage.writeMemory(baseMem, [1, 2, 3]);
 
       // Now make Qdrant fail for update
-      (qdrant.upsert as any).mockRejectedValueOnce(new Error('Qdrant unavailable'));
+      qdrant.upsert.mockRejectedValueOnce(new Error('Qdrant unavailable'));
 
       await expect(
         storage.updateMemory('mem-1', { importance: 0.9, tags: ['b'] }, [4, 5, 6]),
@@ -116,7 +128,7 @@ describe('StorageManager cross-store consistency', () => {
       // SQLite updateMemory should have been called twice: once for update, once for rollback
       expect(sqlite.updateMemory).toHaveBeenCalledTimes(2);
       // Second call should restore original values
-      const rollbackCall = (sqlite.updateMemory as any).mock.calls[1];
+      const rollbackCall = sqlite.updateMemory.mock.calls[1];
       expect(rollbackCall[1]).toEqual({ importance: 0.5, tags: ['a'] });
     });
   });
@@ -130,7 +142,7 @@ describe('StorageManager cross-store consistency', () => {
 
       await storage.writeMemory(baseMem, [1, 2, 3]);
       // Reset the upsert mock count
-      (qdrant.upsert as any).mockClear();
+      qdrant.upsert.mockClear();
 
       await storage.updateMemory('mem-1', { importance: 0.8 });
       expect(qdrant.upsert).not.toHaveBeenCalled();
@@ -144,7 +156,7 @@ describe('StorageManager cross-store consistency', () => {
       const embedding = createMockEmbedding();
       const storage = new StorageManager(sqlite, qdrant, embedding);
 
-      sqlite.getCollection = vi.fn(() => null) as any;
+      sqlite.getCollection = vi.fn(() => null);
       storage.writeMemoryWithoutVector(baseMem);
 
       expect(sqlite.createCollection).toHaveBeenCalledWith('global', 'general', 'test', 3);

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -31,21 +31,7 @@ export class StorageManager {
     }
 
     try {
-      await this.qdrant.upsert(mem.namespace, mem.collection, mem.id, vector, {
-        type: mem.type,
-        tags: mem.tags,
-        collection: mem.collection,
-        content: mem.content,
-        summary: mem.summary,
-        category: mem.category,
-        source: mem.source,
-        importance: mem.importance,
-        retention_tier: mem.retention_tier,
-        decay_eligible: mem.decay_eligible,
-        expires_at: mem.expires_at ? Math.floor(Date.parse(mem.expires_at) / 1000) : null,
-        device_id: mem.device_id ?? null,
-        created_at: mem.created_at,
-      });
+      await this.qdrant.upsert(mem.namespace, mem.collection, mem.id, vector, toQdrantPayload(mem));
       this.sqlite.markVectorSync(mem.id, true);
     } catch (err) {
       this.sqlite.markVectorSync(mem.id, false);
@@ -97,21 +83,11 @@ export class StorageManager {
           existing.collection,
           id,
           newVector,
-          {
-            type: fields.type ?? existing.type,
-            tags: fields.tags ?? existing.tags,
+          toQdrantPayload({
+            ...existing,
+            ...fields,
             collection: existing.collection,
-            content: fields.content ?? existing.content,
-            summary: fields.summary ?? existing.summary,
-            category: fields.category ?? existing.category,
-            source: existing.source,
-            importance: fields.importance ?? existing.importance,
-            retention_tier: fields.retention_tier ?? existing.retention_tier,
-            decay_eligible: fields.decay_eligible ?? existing.decay_eligible,
-            expires_at: (fields.expires_at ?? existing.expires_at) ? Math.floor(Date.parse((fields.expires_at ?? existing.expires_at)! as string) / 1000) : null,
-            device_id: fields.device_id ?? existing.device_id ?? null,
-            created_at: existing.created_at,
-          },
+          }),
         );
         this.sqlite.markVectorSync(id, true);
       } catch (err) {
@@ -190,6 +166,65 @@ export class StorageManager {
     await this.sqlite.reloadFromDisk();
   }
 
+  markAllMemoriesVectorSync(synced: boolean, options?: { allowDuringLifecycle?: boolean }): number {
+    const affected = this.sqlite.markAllVectorsSyncState(synced, options);
+    this.sqlite.flushIfDirty();
+    return affected;
+  }
+
+  async clearManagedVectors(): Promise<number> {
+    return this.qdrant.clearManagedCollections();
+  }
+
+  async reconcileVectorsFromSqlite(
+    options?: { batchSize?: number; allowDuringLifecycle?: boolean },
+  ): Promise<{ reconciled: number; remaining: number }> {
+    const batchSize = options?.batchSize ?? 100;
+    let cursor: string | undefined;
+    let reconciled = 0;
+
+    while (true) {
+      const memories = this.sqlite.listMemoriesNeedingVectorSync(batchSize, cursor);
+      if (memories.length === 0) {
+        break;
+      }
+
+      for (const memory of memories) {
+        this.ensureCollectionCompatible(memory.namespace, memory.collection);
+      }
+
+      const vectors = await this.embedding.embedBatch(memories.map(memory => memory.content));
+
+      for (const [index, memory] of memories.entries()) {
+        const vector = vectors[index];
+        if (!vector) {
+          throw internal(`Missing embedding vector for memory ${memory.id}`);
+        }
+        await this.qdrant.upsert(
+          memory.namespace,
+          memory.collection,
+          memory.id,
+          vector,
+          toQdrantPayload(memory),
+        );
+        this.sqlite.markVectorSync(memory.id, true, {
+          allowDuringLifecycle: options?.allowDuringLifecycle,
+        });
+        reconciled++;
+      }
+
+      this.sqlite.flushIfDirty();
+
+      if (memories.length < batchSize) {
+        break;
+      }
+      const last = memories[memories.length - 1]!;
+      cursor = `${last.created_at}|${last.id}`;
+    }
+
+    return { reconciled, remaining: this.sqlite.countUnsyncedVectors() };
+  }
+
   logAudit(
     operation: WriteOperation | 'FORGET',
     memoryId: string,
@@ -240,4 +275,28 @@ function assignRollbackField<K extends keyof MemoryRecordWithoutEmbedding>(
   value: MemoryRecordWithoutEmbedding[K],
 ): void {
   target[key] = value;
+}
+
+function toQdrantPayload(
+  mem: Pick<
+    MemoryRecordWithoutEmbedding,
+    'type' | 'tags' | 'collection' | 'content' | 'summary' | 'category' | 'source' |
+    'importance' | 'retention_tier' | 'decay_eligible' | 'expires_at' | 'created_at'
+  > & { device_id?: string | null },
+): Record<string, unknown> {
+  return {
+    type: mem.type,
+    tags: mem.tags,
+    collection: mem.collection,
+    content: mem.content,
+    summary: mem.summary,
+    category: mem.category ?? null,
+    source: mem.source,
+    importance: mem.importance,
+    retention_tier: mem.retention_tier,
+    decay_eligible: mem.decay_eligible,
+    expires_at: mem.expires_at ? Math.floor(Date.parse(mem.expires_at) / 1000) : null,
+    device_id: mem.device_id ?? null,
+    created_at: mem.created_at,
+  };
 }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -198,19 +198,26 @@ export class StorageManager {
       for (const [index, memory] of memories.entries()) {
         const vector = vectors[index];
         if (!vector) {
+          this.sqlite.flushIfDirty();
           throw internal(`Missing embedding vector for memory ${memory.id}`);
         }
-        await this.qdrant.upsert(
-          memory.namespace,
-          memory.collection,
-          memory.id,
-          vector,
-          toQdrantPayload(memory),
-        );
-        this.sqlite.markVectorSync(memory.id, true, {
-          allowDuringLifecycle: options?.allowDuringLifecycle,
-        });
-        reconciled++;
+
+        try {
+          await this.qdrant.upsert(
+            memory.namespace,
+            memory.collection,
+            memory.id,
+            vector,
+            toQdrantPayload(memory),
+          );
+          this.sqlite.markVectorSync(memory.id, true, {
+            allowDuringLifecycle: options?.allowDuringLifecycle,
+          });
+          reconciled++;
+        } catch (err) {
+          this.sqlite.flushIfDirty();
+          throw err;
+        }
       }
 
       this.sqlite.flushIfDirty();

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -5,6 +5,8 @@ import type { EmbeddingProvider } from '../embedding/index.js';
 import type { MemoryRecord, WriteOperation, AuditEntry } from '../domain/types.js';
 import { internal, conflict } from '../errors/index.js';
 
+type MemoryRecordWithoutEmbedding = Omit<MemoryRecord, 'embedding'>;
+
 export class StorageManager {
   constructor(
     public readonly sqlite: SqliteStore,
@@ -17,7 +19,7 @@ export class StorageManager {
   }
 
   async writeMemory(
-    mem: Omit<MemoryRecord, 'embedding'>,
+    mem: MemoryRecordWithoutEmbedding,
     vector: number[],
   ): Promise<void> {
     this.ensureCollectionCompatible(mem.namespace, mem.collection);
@@ -44,13 +46,9 @@ export class StorageManager {
         device_id: mem.device_id ?? null,
         created_at: mem.created_at,
       });
-      if (typeof (this.sqlite as any).markVectorSync === 'function') {
-        this.sqlite.markVectorSync(mem.id, true);
-      }
+      this.sqlite.markVectorSync(mem.id, true);
     } catch (err) {
-      if (typeof (this.sqlite as any).markVectorSync === 'function') {
-        this.sqlite.markVectorSync(mem.id, false);
-      }
+      this.sqlite.markVectorSync(mem.id, false);
       this.sqlite.flushIfDirty();
       throw internal(`Qdrant write failed after SQLite persistence: ${(err as Error).message}`);
     }
@@ -58,7 +56,7 @@ export class StorageManager {
     this.sqlite.flushIfDirty();
   }
 
-  writeMemoryWithoutVector(mem: Omit<MemoryRecord, 'embedding'>): void {
+  writeMemoryWithoutVector(mem: MemoryRecordWithoutEmbedding): void {
     this.ensureCollectionCompatible(mem.namespace, mem.collection);
     try {
       this.sqlite.insertMemory({
@@ -80,9 +78,10 @@ export class StorageManager {
     if (!existing) throw internal(`Memory ${id} not found for update`);
 
     // Snapshot fields that will change for rollback
-    const rollbackFields: Partial<Omit<MemoryRecord, 'embedding'>> = {};
-    for (const key of Object.keys(fields) as Array<keyof typeof fields>) {
-      (rollbackFields as any)[key] = (existing as any)[key];
+    const rollbackFields: Partial<MemoryRecordWithoutEmbedding> = {};
+    for (const key of Object.keys(fields) as Array<keyof MemoryRecordWithoutEmbedding>) {
+      const currentValue = existing[key];
+      assignRollbackField(rollbackFields, key, currentValue);
     }
 
     if (existing.retention_tier === 'T0' && fields.content && fields.content !== existing.content) {
@@ -114,14 +113,10 @@ export class StorageManager {
             created_at: existing.created_at,
           },
         );
-        if (typeof (this.sqlite as any).markVectorSync === 'function') {
-          this.sqlite.markVectorSync(id, true);
-        }
+        this.sqlite.markVectorSync(id, true);
       } catch (err) {
         this.sqlite.updateMemory(id, rollbackFields);
-        if (typeof (this.sqlite as any).markVectorSync === 'function') {
-          this.sqlite.markVectorSync(id, false);
-        }
+        this.sqlite.markVectorSync(id, false);
         this.sqlite.flushIfDirty();
         throw internal(`Qdrant update failed, rolled back SQLite: ${(err as Error).message}`);
       }
@@ -238,3 +233,11 @@ export class StorageManager {
 
 export { SqliteStore } from './sqlite.js';
 export { QdrantStore } from './qdrant.js';
+
+function assignRollbackField<K extends keyof MemoryRecordWithoutEmbedding>(
+  target: Partial<MemoryRecordWithoutEmbedding>,
+  key: K,
+  value: MemoryRecordWithoutEmbedding[K],
+): void {
+  target[key] = value;
+}

--- a/src/storage/qdrant.ts
+++ b/src/storage/qdrant.ts
@@ -1,5 +1,8 @@
 import { QdrantClient } from '@qdrant/js-client-rest';
 import type { BrainConfig } from '../config/index.js';
+import type { CircuitBreaker } from '../resilience/index.js';
+import { CircuitOpenError } from '../resilience/index.js';
+import { internal } from '../errors/index.js';
 
 const COLLECTION_PREFIX = 'bhgbrain_';
 
@@ -7,7 +10,10 @@ export class QdrantStore {
   private client: QdrantClient;
   private dimensions: number;
 
-  constructor(private config: BrainConfig) {
+  constructor(
+    private config: BrainConfig,
+    private readonly breaker?: CircuitBreaker,
+  ) {
     this.dimensions = config.embedding.dimensions;
 
     if (config.qdrant.mode === 'external' && config.qdrant.external_url) {
@@ -74,31 +80,35 @@ export class QdrantStore {
     vector: number[],
     payload: Record<string, unknown>,
   ): Promise<void> {
-    const name = this.collectionName(namespace, collection);
-    await this.ensureCollection(namespace, collection);
-    await this.client.upsert(name, {
-      wait: true,
-      points: [{
-        id,
-        vector,
-        payload: { ...payload, namespace },
-      }],
+    await this.executeWithBreaker(async () => {
+      const name = this.collectionName(namespace, collection);
+      await this.ensureCollection(namespace, collection);
+      await this.client.upsert(name, {
+        wait: true,
+        points: [{
+          id,
+          vector,
+          payload: { ...payload, namespace },
+        }],
+      });
     });
   }
 
   async delete(namespace: string, collection: string, id: string): Promise<void> {
-    const name = this.collectionName(namespace, collection);
-    try {
-      await this.client.delete(name, {
-        wait: true,
-        points: [id],
-      });
-    } catch (err) {
-      if (this.isNotFoundError(err)) {
-        return;
+    await this.executeWithBreaker(async () => {
+      const name = this.collectionName(namespace, collection);
+      try {
+        await this.client.delete(name, {
+          wait: true,
+          points: [id],
+        });
+      } catch (err) {
+        if (this.isNotFoundError(err)) {
+          return;
+        }
+        throw err;
       }
-      throw err;
-    }
+    });
   }
 
   async deleteMany(namespace: string, collection: string, ids: string[]): Promise<void> {
@@ -131,7 +141,7 @@ export class QdrantStore {
     const collName = collection ?? 'general';
     const name = this.collectionName(namespace, collName);
 
-    const must: any[] = [
+    const must: Array<Record<string, unknown>> = [
       { key: 'namespace', match: { value: namespace } },
     ];
     if (filters?.type) {
@@ -145,13 +155,13 @@ export class QdrantStore {
       ],
     });
 
-    const results = await this.client.search(name, {
+    const results = await this.executeWithBreaker(() => this.client.search(name, {
       vector,
       limit,
       filter: must.length > 0 ? { must } : undefined,
       score_threshold: filters?.minScore,
       with_payload: true,
-    });
+    }));
 
     return results.map(r => ({
       id: r.id as string,
@@ -266,5 +276,20 @@ export class QdrantStore {
     if (status === 404) return true;
     const message = maybeErr.message?.toLowerCase() ?? '';
     return message.includes('not found') || message.includes('does not exist');
+  }
+
+  private async executeWithBreaker<T>(fn: () => Promise<T>): Promise<T> {
+    if (!this.breaker) {
+      return fn();
+    }
+
+    try {
+      return await this.breaker.execute(fn);
+    } catch (error) {
+      if (error instanceof CircuitOpenError) {
+        throw internal('Qdrant circuit breaker is open');
+      }
+      throw error;
+    }
   }
 }

--- a/src/storage/qdrant.ts
+++ b/src/storage/qdrant.ts
@@ -292,4 +292,24 @@ export class QdrantStore {
       throw error;
     }
   }
+
+  async clearManagedCollections(): Promise<number> {
+    const collections = await this.executeWithBreaker(() => this.client.getCollections());
+    const managedNames = (collections.collections ?? [])
+      .map(collection => collection.name)
+      .filter((name): name is string => typeof name === 'string' && name.startsWith(COLLECTION_PREFIX));
+
+    for (const name of managedNames) {
+      try {
+        await this.executeWithBreaker(() => this.client.deleteCollection(name));
+      } catch (err) {
+        if (this.isNotFoundError(err)) {
+          continue;
+        }
+        throw err;
+      }
+    }
+
+    return managedNames.length;
+  }
 }

--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -11,6 +11,108 @@ import type {
   TierStats,
 } from '../domain/types.js';
 
+type SqlValue = string | number | null | Uint8Array;
+export type SqlParams = SqlValue[];
+
+type SqlRow = Record<string, SqlValue | undefined>;
+
+type MemoryRecordWithoutEmbedding = Omit<MemoryRecord, 'embedding'>;
+
+export interface AccessUpdate {
+  id: string;
+  access_count: number;
+  last_accessed: string;
+  expires_at?: string | null;
+  retention_tier?: RetentionTier;
+  review_due?: string | null;
+}
+
+export interface CategoryHeader {
+  name: string;
+  slot: string;
+  updated_at: string;
+  revision: number;
+  content_length: number;
+}
+
+export interface CollectionRecord {
+  name: string;
+  namespace: string;
+  embedding_model: string;
+  embedding_dimensions: number;
+}
+
+export interface SqliteStorage {
+  init(): Promise<void>;
+  reloadFromDisk(): Promise<void>;
+  flush(): void;
+  flushIfDirty(): void;
+  scheduleDeferredFlush(): void;
+  cancelDeferredFlush(): void;
+  insertMemory(mem: MemoryRecordWithoutEmbedding): void;
+  updateMemory(id: string, fields: Partial<MemoryRecordWithoutEmbedding>): void;
+  deleteMemory(id: string): boolean;
+  getMemoryById(id: string, includeArchived?: boolean): MemoryRecordWithoutEmbedding | null;
+  getMemoryByChecksum(namespace: string, checksum: string): MemoryRecordWithoutEmbedding | null;
+  listMemories(namespace: string, limit: number, cursor?: string): MemoryRecordWithoutEmbedding[];
+  countMemories(namespace?: string): number;
+  countMemoriesInCollection(namespace: string, collection: string): number;
+  fullTextSearch(namespace: string, query: string, limit: number, collection?: string): Array<{ id: string; rank: number }>;
+  markStale(memoryId: string): void;
+  getStaleMemories(importanceBelow: number, limit: number): MemoryRecordWithoutEmbedding[];
+  listStaleCandidateIds(cutoffIso: string): string[];
+  touchMemory(id: string): void;
+  recordAccess(
+    id: string,
+    accessCount: number,
+    lastAccessed: string,
+    expiresAt?: string | null,
+    retentionTier?: RetentionTier,
+    reviewDue?: string | null,
+  ): void;
+  markVectorSync(id: string, synced: boolean): void;
+  recordAccessBatch(updates: AccessUpdate[]): void;
+  listExpiredMemories(nowIso: string, tier?: RetentionTier): MemoryRecordWithoutEmbedding[];
+  listExpiringMemories(nowIso: string, untilIso: string, limit: number): MemoryRecordWithoutEmbedding[];
+  countExpiringMemories(nowIso: string, untilIso: string): number;
+  countByTier(): Record<RetentionTier, number>;
+  getTierStats(): TierStats[];
+  countArchivedMemories(): number;
+  countUnsyncedVectors(): number;
+  archiveMemory(memory: MemoryRecordWithoutEmbedding, expiredAt: string): void;
+  listArchive(limit: number): ArchiveRecord[];
+  searchArchive(query: string, limit: number): ArchiveRecord[];
+  getArchiveByMemoryId(memoryId: string): ArchiveRecord | null;
+  deleteArchive(memoryId: string): void;
+  insertRevision(memoryId: string, revision: number, content: string, updatedAt: string, updatedBy?: string): void;
+  listRevisions(memoryId: string): MemoryRevisionRecord[];
+  getDbSizeBytes(): number;
+  setCategory(name: string, slot: string, content: string): CategoryRecord;
+  getCategory(name: string): CategoryRecord | null;
+  listCategories(): CategoryRecord[];
+  deleteCategory(name: string): boolean;
+  createCollection(namespace: string, name: string, embeddingModel: string, embeddingDimensions: number): void;
+  getCollection(namespace: string, name: string): CollectionRecord | null;
+  listCollections(namespace?: string): Array<{ name: string; count: number }>;
+  deleteCollection(namespace: string, name: string): boolean;
+  deleteMemoriesInCollection(namespace: string, collection: string): { deleted: number; ids: string[] };
+  insertAudit(entry: AuditEntry): void;
+  listAudit(limit: number): AuditEntry[];
+  insertBackupMeta(path: string, sizeBytes: number, memoryCount: number, checksum: string): void;
+  listBackups(): Array<{ path: string; size_bytes: number; memory_count: number; created_at: string }>;
+  exportData(): Buffer;
+  getDatabasePath(): string;
+  healthCheck(): boolean;
+  close(): void;
+  beginLifecycleOperation(reason: string): void;
+  endLifecycleOperation(reason?: string): void;
+  isLifecycleOperationInProgress(): boolean;
+  getMemoriesByIds(ids: string[]): MemoryRecordWithoutEmbedding[];
+  listMemoryIdsInCollection(namespace: string, collection: string): string[];
+  listCategoryHeaders(): CategoryHeader[];
+  getCategoryContentSlice(name: string, maxChars: number): string | null;
+}
+
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS memories (
   id TEXT PRIMARY KEY,
@@ -125,7 +227,7 @@ CREATE INDEX IF NOT EXISTS idx_memory_archive_memory_id ON memory_archive(memory
 CREATE INDEX IF NOT EXISTS idx_memory_archive_expired_at ON memory_archive(expired_at DESC);
 `;
 
-export class SqliteStore {
+export class SqliteStore implements SqliteStorage {
   private db!: Database;
   private dbPath: string;
   private dirty = false;
@@ -199,7 +301,7 @@ export class SqliteStore {
     }
   }
 
-  insertMemory(mem: Omit<MemoryRecord, 'embedding'>): void {
+  insertMemory(mem: MemoryRecordWithoutEmbedding): void {
     this.assertMutableAllowed();
     const retentionTier = mem.retention_tier ?? 'T2';
     const expiresAt = mem.expires_at ?? null;
@@ -249,11 +351,15 @@ export class SqliteStore {
     this.markDirty();
   }
 
-  updateMemory(id: string, fields: Partial<Omit<MemoryRecord, 'embedding'>>): void {
+  updateMemory(id: string, fields: Partial<MemoryRecordWithoutEmbedding>): void {
     this.assertMutableAllowed();
     const sets: string[] = [];
-    const vals: unknown[] = [];
-    for (const [key, val] of Object.entries(fields)) {
+    const vals: SqlParams = [];
+    for (const key of Object.keys(fields) as Array<keyof MemoryRecordWithoutEmbedding>) {
+      const val = fields[key];
+      if (val === undefined) {
+        continue;
+      }
       if (key === 'tags') {
         sets.push('tags = ?');
         vals.push(JSON.stringify(val));
@@ -262,12 +368,12 @@ export class SqliteStore {
         vals.push(val ? 1 : 0);
       } else {
         sets.push(`${key} = ?`);
-        vals.push(val);
+        vals.push(this.toSqlValue(val, key));
       }
     }
     if (sets.length === 0) return;
     vals.push(id);
-    this.db.run(`UPDATE memories SET ${sets.join(', ')} WHERE id = ?`, vals as any[]);
+    this.db.run(`UPDATE memories SET ${sets.join(', ')} WHERE id = ?`, vals);
 
     if (fields.content || fields.summary || fields.tags || fields.archived) {
       this.db.run(`DELETE FROM memories_fts WHERE id = ?`, [id]);
@@ -292,7 +398,7 @@ export class SqliteStore {
     return true;
   }
 
-  getMemoryById(id: string, includeArchived = false): Omit<MemoryRecord, 'embedding'> | null {
+  getMemoryById(id: string, includeArchived = false): MemoryRecordWithoutEmbedding | null {
     const sql = includeArchived
       ? `SELECT * FROM memories WHERE id = ?`
       : `SELECT * FROM memories WHERE id = ? AND archived = 0`;
@@ -302,26 +408,26 @@ export class SqliteStore {
       stmt.free();
       return null;
     }
-    const row = stmt.getAsObject();
+    const row = this.getRow(stmt.getAsObject());
     stmt.free();
     return this.rowToMemory(row);
   }
 
-  getMemoryByChecksum(namespace: string, checksum: string): Omit<MemoryRecord, 'embedding'> | null {
+  getMemoryByChecksum(namespace: string, checksum: string): MemoryRecordWithoutEmbedding | null {
     const stmt = this.db.prepare(`SELECT * FROM memories WHERE namespace = ? AND checksum = ? AND archived = 0 LIMIT 1`);
     stmt.bind([namespace, checksum]);
     if (!stmt.step()) {
       stmt.free();
       return null;
     }
-    const row = stmt.getAsObject();
+    const row = this.getRow(stmt.getAsObject());
     stmt.free();
     return this.rowToMemory(row);
   }
 
-  listMemories(namespace: string, limit: number, cursor?: string): Array<Omit<MemoryRecord, 'embedding'>> {
+  listMemories(namespace: string, limit: number, cursor?: string): MemoryRecordWithoutEmbedding[] {
     let sql = `SELECT * FROM memories WHERE namespace = ? AND archived = 0`;
-    const params: unknown[] = [namespace];
+    const params: SqlParams = [namespace];
     if (cursor) {
       const sepIdx = cursor.indexOf('|');
       if (sepIdx !== -1) {
@@ -368,7 +474,7 @@ export class SqliteStore {
     if (terms.length === 0) return [];
 
     const conditions = terms.map(() => `(LOWER(f.content) LIKE ? OR LOWER(f.summary) LIKE ? OR LOWER(f.tags) LIKE ?)`);
-    const params: unknown[] = [namespace];
+    const params: SqlParams = [namespace];
 
     let collectionJoin = ' JOIN memories m ON f.id = m.id AND m.archived = 0';
     if (collection) {
@@ -384,11 +490,11 @@ export class SqliteStore {
 
     const sql = `SELECT f.id, ${terms.length} as rank FROM memories_fts f${collectionJoin} WHERE f.namespace = ? AND ${conditions.join(' AND ')} LIMIT ?`;
     const stmt = this.db.prepare(sql);
-    stmt.bind(params as any[]);
+    stmt.bind(params);
     const results: Array<{ id: string; rank: number }> = [];
     while (stmt.step()) {
-      const row = stmt.getAsObject() as { id: string; rank: number };
-      results.push({ id: row.id, rank: -terms.length });
+      const row = this.getRow(stmt.getAsObject());
+      results.push({ id: this.getString(row, 'id'), rank: -terms.length });
     }
     stmt.free();
     return results;
@@ -399,7 +505,7 @@ export class SqliteStore {
     this.markDirty();
   }
 
-  getStaleMemories(importanceBelow: number, limit: number): Array<Omit<MemoryRecord, 'embedding'>> {
+  getStaleMemories(importanceBelow: number, limit: number): MemoryRecordWithoutEmbedding[] {
     return this.queryMemories(
       `SELECT * FROM memories WHERE stale = 1 AND importance < ? AND category IS NULL AND archived = 0 ORDER BY importance ASC LIMIT ?`,
       [importanceBelow, limit],
@@ -413,8 +519,8 @@ export class SqliteStore {
     stmt.bind([cutoffIso]);
     const ids: string[] = [];
     while (stmt.step()) {
-      const row = stmt.getAsObject() as { id: string };
-      ids.push(row.id);
+      const row = this.getRow(stmt.getAsObject());
+      ids.push(this.getString(row, 'id'));
     }
     stmt.free();
     return ids;
@@ -440,7 +546,7 @@ export class SqliteStore {
   ): void {
     if (this.lifecycleOperation) return;
     const sets = ['access_count = ?', 'last_accessed = ?'];
-    const params: unknown[] = [accessCount, lastAccessed];
+    const params: SqlParams = [accessCount, lastAccessed];
     if (expiresAt !== undefined) {
       sets.push('expires_at = ?');
       params.push(expiresAt);
@@ -454,7 +560,7 @@ export class SqliteStore {
       params.push(reviewDue);
     }
     params.push(id);
-    this.db.run(`UPDATE memories SET ${sets.join(', ')} WHERE id = ?`, params as any[]);
+    this.db.run(`UPDATE memories SET ${sets.join(', ')} WHERE id = ?`, params);
     this.markDirty();
   }
 
@@ -465,19 +571,12 @@ export class SqliteStore {
   }
 
   recordAccessBatch(
-    updates: Array<{
-      id: string;
-      access_count: number;
-      last_accessed: string;
-      expires_at?: string | null;
-      retention_tier?: RetentionTier;
-      review_due?: string | null;
-    }>,
+    updates: AccessUpdate[],
   ): void {
     if (this.lifecycleOperation || updates.length === 0) return;
     for (const update of updates) {
       const sets = ['access_count = ?', 'last_accessed = ?'];
-      const params: unknown[] = [update.access_count, update.last_accessed];
+      const params: SqlParams = [update.access_count, update.last_accessed];
       if (update.expires_at !== undefined) {
         sets.push('expires_at = ?');
         params.push(update.expires_at);
@@ -491,12 +590,12 @@ export class SqliteStore {
         params.push(update.review_due);
       }
       params.push(update.id);
-      this.db.run(`UPDATE memories SET ${sets.join(', ')} WHERE id = ?`, params as any[]);
+      this.db.run(`UPDATE memories SET ${sets.join(', ')} WHERE id = ?`, params);
     }
     this.markDirty();
   }
 
-  listExpiredMemories(nowIso: string, tier?: RetentionTier): Array<Omit<MemoryRecord, 'embedding'>> {
+  listExpiredMemories(nowIso: string, tier?: RetentionTier): MemoryRecordWithoutEmbedding[] {
     const sql = tier
       ? `SELECT * FROM memories WHERE archived = 0 AND decay_eligible = 1 AND expires_at IS NOT NULL AND expires_at < ? AND retention_tier = ? ORDER BY expires_at ASC`
       : `SELECT * FROM memories WHERE archived = 0 AND decay_eligible = 1 AND expires_at IS NOT NULL AND expires_at < ? ORDER BY expires_at ASC`;
@@ -504,7 +603,7 @@ export class SqliteStore {
     return this.queryMemories(sql, params);
   }
 
-  listExpiringMemories(nowIso: string, untilIso: string, limit: number): Array<Omit<MemoryRecord, 'embedding'>> {
+  listExpiringMemories(nowIso: string, untilIso: string, limit: number): MemoryRecordWithoutEmbedding[] {
     return this.queryMemories(
       `SELECT * FROM memories WHERE archived = 0 AND expires_at IS NOT NULL AND expires_at >= ? AND expires_at <= ? ORDER BY expires_at ASC LIMIT ?`,
       [nowIso, untilIso, limit],
@@ -556,7 +655,7 @@ export class SqliteStore {
     return row.cnt;
   }
 
-  archiveMemory(memory: Omit<MemoryRecord, 'embedding'>, expiredAt: string): void {
+  archiveMemory(memory: MemoryRecordWithoutEmbedding, expiredAt: string): void {
     this.db.run(
       `INSERT INTO memory_archive (memory_id, summary, tier, namespace, created_at, expired_at, access_count, tags)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -631,14 +730,14 @@ export class SqliteStore {
     stmt.bind([memoryId]);
     const results: MemoryRevisionRecord[] = [];
     while (stmt.step()) {
-      const row = stmt.getAsObject() as any;
+      const row = this.getRow(stmt.getAsObject());
       results.push({
-        id: row.id,
-        memory_id: row.memory_id,
-        revision: row.revision,
-        content: row.content,
-        updated_at: row.updated_at,
-        updated_by: row.updated_by ?? null,
+        id: this.getNumber(row, 'id'),
+        memory_id: this.getString(row, 'memory_id'),
+        revision: this.getNumber(row, 'revision'),
+        content: this.getString(row, 'content'),
+        updated_at: this.getString(row, 'updated_at'),
+        updated_by: this.getNullableString(row, 'updated_by'),
       });
     }
     stmt.free();
@@ -679,17 +778,29 @@ export class SqliteStore {
       stmt.free();
       return null;
     }
-    const row = stmt.getAsObject() as any;
+    const row = this.getRow(stmt.getAsObject());
     stmt.free();
-    return { name: row.name, slot: row.slot, content: row.content, updated_at: row.updated_at, revision: row.revision };
+    return {
+      name: this.getString(row, 'name'),
+      slot: this.getString(row, 'slot') as CategoryRecord['slot'],
+      content: this.getString(row, 'content'),
+      updated_at: this.getString(row, 'updated_at'),
+      revision: this.getNumber(row, 'revision'),
+    };
   }
 
   listCategories(): CategoryRecord[] {
     const stmt = this.db.prepare(`SELECT * FROM categories ORDER BY name`);
     const results: CategoryRecord[] = [];
     while (stmt.step()) {
-      const row = stmt.getAsObject() as any;
-      results.push({ name: row.name, slot: row.slot, content: row.content, updated_at: row.updated_at, revision: row.revision });
+      const row = this.getRow(stmt.getAsObject());
+      results.push({
+        name: this.getString(row, 'name'),
+        slot: this.getString(row, 'slot') as CategoryRecord['slot'],
+        content: this.getString(row, 'content'),
+        updated_at: this.getString(row, 'updated_at'),
+        revision: this.getNumber(row, 'revision'),
+      });
     }
     stmt.free();
     return results;
@@ -714,16 +825,21 @@ export class SqliteStore {
     this.markDirty();
   }
 
-  getCollection(namespace: string, name: string): { name: string; namespace: string; embedding_model: string; embedding_dimensions: number } | null {
+  getCollection(namespace: string, name: string): CollectionRecord | null {
     const stmt = this.db.prepare(`SELECT * FROM collections WHERE namespace = ? AND name = ?`);
     stmt.bind([namespace, name]);
     if (!stmt.step()) {
       stmt.free();
       return null;
     }
-    const row = stmt.getAsObject() as any;
+    const row = this.getRow(stmt.getAsObject());
     stmt.free();
-    return { name: row.name, namespace: row.namespace, embedding_model: row.embedding_model, embedding_dimensions: row.embedding_dimensions };
+    return {
+      name: this.getString(row, 'name'),
+      namespace: this.getString(row, 'namespace'),
+      embedding_model: this.getString(row, 'embedding_model'),
+      embedding_dimensions: this.getNumber(row, 'embedding_dimensions'),
+    };
   }
 
   listCollections(namespace?: string): Array<{ name: string; count: number }> {
@@ -735,8 +851,8 @@ export class SqliteStore {
     stmt.bind(params);
     const results: Array<{ name: string; count: number }> = [];
     while (stmt.step()) {
-      const row = stmt.getAsObject() as any;
-      results.push({ name: row.name, count: row.count });
+      const row = this.getRow(stmt.getAsObject());
+      results.push({ name: this.getString(row, 'name'), count: this.getNumber(row, 'count') });
     }
     stmt.free();
     return results;
@@ -760,8 +876,8 @@ export class SqliteStore {
     select.bind([namespace, collection]);
     const ids: string[] = [];
     while (select.step()) {
-      const row = select.getAsObject() as { id: string };
-      ids.push(row.id);
+      const row = this.getRow(select.getAsObject());
+      ids.push(this.getString(row, 'id'));
     }
     select.free();
 
@@ -794,15 +910,15 @@ export class SqliteStore {
     stmt.bind([limit]);
     const results: AuditEntry[] = [];
     while (stmt.step()) {
-      const row = stmt.getAsObject() as any;
+      const row = this.getRow(stmt.getAsObject());
       results.push({
-        id: row.id,
-        timestamp: row.timestamp,
-        namespace: row.namespace,
-        operation: row.operation,
-        memory_id: row.memory_id,
-        client_id: row.client_id,
-        details: row.details,
+        id: this.getString(row, 'id'),
+        timestamp: this.getString(row, 'timestamp'),
+        namespace: this.getString(row, 'namespace'),
+        operation: this.getString(row, 'operation') as AuditEntry['operation'],
+        memory_id: this.getString(row, 'memory_id'),
+        client_id: this.getString(row, 'client_id'),
+        details: this.getNullableString(row, 'details') ?? undefined,
       });
     }
     stmt.free();
@@ -822,8 +938,13 @@ export class SqliteStore {
     const stmt = this.db.prepare(`SELECT * FROM backup_metadata ORDER BY created_at DESC`);
     const results: Array<{ path: string; size_bytes: number; memory_count: number; created_at: string }> = [];
     while (stmt.step()) {
-      const row = stmt.getAsObject() as any;
-      results.push({ path: row.path, size_bytes: row.size_bytes, memory_count: row.memory_count, created_at: row.created_at });
+      const row = this.getRow(stmt.getAsObject());
+      results.push({
+        path: this.getString(row, 'path'),
+        size_bytes: this.getNumber(row, 'size_bytes'),
+        memory_count: this.getNumber(row, 'memory_count'),
+        created_at: this.getString(row, 'created_at'),
+      });
     }
     stmt.free();
     return results;
@@ -873,7 +994,7 @@ export class SqliteStore {
     return this.lifecycleOperation !== null;
   }
 
-  getMemoriesByIds(ids: string[]): Array<Omit<MemoryRecord, 'embedding'>> {
+  getMemoriesByIds(ids: string[]): MemoryRecordWithoutEmbedding[] {
     if (ids.length === 0) return [];
     const placeholders = ids.map(() => '?').join(', ');
     return this.queryMemories(
@@ -887,24 +1008,24 @@ export class SqliteStore {
     stmt.bind([namespace, collection]);
     const ids: string[] = [];
     while (stmt.step()) {
-      const row = stmt.getAsObject() as { id: string };
-      ids.push(row.id);
+      const row = this.getRow(stmt.getAsObject());
+      ids.push(this.getString(row, 'id'));
     }
     stmt.free();
     return ids;
   }
 
-  listCategoryHeaders(): Array<{ name: string; slot: string; updated_at: string; revision: number; content_length: number }> {
+  listCategoryHeaders(): CategoryHeader[] {
     const stmt = this.db.prepare(`SELECT name, slot, updated_at, revision, LENGTH(content) as content_length FROM categories ORDER BY name`);
-    const results: Array<{ name: string; slot: string; updated_at: string; revision: number; content_length: number }> = [];
+    const results: CategoryHeader[] = [];
     while (stmt.step()) {
-      const row = stmt.getAsObject() as any;
+      const row = this.getRow(stmt.getAsObject());
       results.push({
-        name: row.name,
-        slot: row.slot,
-        updated_at: row.updated_at,
-        revision: row.revision,
-        content_length: row.content_length,
+        name: this.getString(row, 'name'),
+        slot: this.getString(row, 'slot'),
+        updated_at: this.getString(row, 'updated_at'),
+        revision: this.getNumber(row, 'revision'),
+        content_length: this.getNumber(row, 'content_length'),
       });
     }
     stmt.free();
@@ -918,62 +1039,62 @@ export class SqliteStore {
       stmt.free();
       return null;
     }
-    const row = stmt.getAsObject() as { content: string };
+    const row = this.getRow(stmt.getAsObject());
     stmt.free();
-    return row.content ?? '';
+    return this.getNullableString(row, 'content') ?? '';
   }
 
-  private queryMemories(sql: string, params: unknown[]): Array<Omit<MemoryRecord, 'embedding'>> {
+  private queryMemories(sql: string, params: SqlParams): MemoryRecordWithoutEmbedding[] {
     const stmt = this.db.prepare(sql);
-    stmt.bind(params as any[]);
-    const results: Array<Omit<MemoryRecord, 'embedding'>> = [];
+    stmt.bind(params);
+    const results: MemoryRecordWithoutEmbedding[] = [];
     while (stmt.step()) {
-      results.push(this.rowToMemory(stmt.getAsObject()));
+      results.push(this.rowToMemory(this.getRow(stmt.getAsObject())));
     }
     stmt.free();
     return results;
   }
 
-  private rowToMemory(row: any): Omit<MemoryRecord, 'embedding'> {
+  private rowToMemory(row: SqlRow): MemoryRecordWithoutEmbedding {
     return {
-      id: row.id,
-      namespace: row.namespace,
-      collection: row.collection,
-      type: row.type,
-      category: row.category ?? null,
-      content: row.content,
-      summary: row.summary,
-      tags: JSON.parse(row.tags || '[]'),
-      source: row.source,
-      checksum: row.checksum,
-      importance: row.importance,
-      retention_tier: row.retention_tier ?? 'T2',
-      expires_at: row.expires_at ?? null,
-      decay_eligible: Boolean(row.decay_eligible),
-      review_due: row.review_due ?? null,
-      access_count: row.access_count,
-      last_operation: row.last_operation,
-      merged_from: row.merged_from ?? null,
-      archived: Boolean(row.archived),
-      vector_synced: row.vector_synced === undefined ? true : Boolean(row.vector_synced),
-      device_id: row.device_id ?? null,
-      created_at: row.created_at,
-      updated_at: row.updated_at,
-      last_accessed: row.last_accessed,
+      id: this.getString(row, 'id'),
+      namespace: this.getString(row, 'namespace'),
+      collection: this.getString(row, 'collection'),
+      type: this.getString(row, 'type') as MemoryRecord['type'],
+      category: this.getNullableString(row, 'category'),
+      content: this.getString(row, 'content'),
+      summary: this.getString(row, 'summary'),
+      tags: JSON.parse(this.getNullableString(row, 'tags') ?? '[]') as string[],
+      source: this.getString(row, 'source') as MemoryRecord['source'],
+      checksum: this.getString(row, 'checksum'),
+      importance: this.getNumber(row, 'importance'),
+      retention_tier: (this.getNullableString(row, 'retention_tier') ?? 'T2') as RetentionTier,
+      expires_at: this.getNullableString(row, 'expires_at'),
+      decay_eligible: this.getBoolean(row, 'decay_eligible'),
+      review_due: this.getNullableString(row, 'review_due'),
+      access_count: this.getNumber(row, 'access_count'),
+      last_operation: this.getString(row, 'last_operation') as MemoryRecord['last_operation'],
+      merged_from: this.getNullableString(row, 'merged_from'),
+      archived: this.getBoolean(row, 'archived'),
+      vector_synced: row.vector_synced === undefined ? true : this.getBoolean(row, 'vector_synced'),
+      device_id: this.getNullableString(row, 'device_id'),
+      created_at: this.getString(row, 'created_at'),
+      updated_at: this.getString(row, 'updated_at'),
+      last_accessed: this.getString(row, 'last_accessed'),
     };
   }
 
-  private rowToArchive(row: any): ArchiveRecord {
+  private rowToArchive(row: SqlRow): ArchiveRecord {
     return {
-      id: row.id,
-      memory_id: row.memory_id,
-      summary: row.summary,
-      tier: row.tier,
-      namespace: row.namespace,
-      created_at: row.created_at,
-      expired_at: row.expired_at,
-      access_count: row.access_count,
-      tags: JSON.parse(row.tags || '[]'),
+      id: this.getNumber(row, 'id'),
+      memory_id: this.getString(row, 'memory_id'),
+      summary: this.getString(row, 'summary'),
+      tier: this.getString(row, 'tier') as RetentionTier,
+      namespace: this.getString(row, 'namespace'),
+      created_at: this.getString(row, 'created_at'),
+      expired_at: this.getString(row, 'expired_at'),
+      access_count: this.getNumber(row, 'access_count'),
+      tags: JSON.parse(this.getNullableString(row, 'tags') ?? '[]') as string[],
     };
   }
 
@@ -990,8 +1111,8 @@ export class SqliteStore {
     const existingColumns = new Set<string>();
     const stmt = this.db.prepare(`PRAGMA table_info(memories)`);
     while (stmt.step()) {
-      const row = stmt.getAsObject() as { name: string };
-      existingColumns.add(row.name);
+      const row = this.getRow(stmt.getAsObject());
+      existingColumns.add(this.getString(row, 'name'));
     }
     stmt.free();
 
@@ -1016,6 +1137,48 @@ export class SqliteStore {
     if (this.lifecycleOperation) {
       throw new Error(`Storage lifecycle operation in progress: ${this.lifecycleOperation}`);
     }
+  }
+
+  private getRow(value: unknown): SqlRow {
+    return value as SqlRow;
+  }
+
+  private getString(row: SqlRow, key: string): string {
+    const value = row[key];
+    if (typeof value !== 'string') {
+      throw new Error(`Expected string column "${key}"`);
+    }
+    return value;
+  }
+
+  private getNullableString(row: SqlRow, key: string): string | null {
+    const value = row[key];
+    if (value == null) {
+      return null;
+    }
+    if (typeof value !== 'string') {
+      throw new Error(`Expected nullable string column "${key}"`);
+    }
+    return value;
+  }
+
+  private getNumber(row: SqlRow, key: string): number {
+    const value = row[key];
+    if (typeof value !== 'number') {
+      throw new Error(`Expected number column "${key}"`);
+    }
+    return value;
+  }
+
+  private getBoolean(row: SqlRow, key: string): boolean {
+    return Boolean(this.getNumber(row, key));
+  }
+
+  private toSqlValue(value: string | number | boolean | string[] | null, key: string): SqlValue {
+    if (typeof value === 'string' || typeof value === 'number' || value === null) {
+      return value;
+    }
+    throw new Error(`Unsupported SQL value for "${key}"`);
   }
 }
 

--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -70,7 +70,8 @@ export interface SqliteStorage {
     retentionTier?: RetentionTier,
     reviewDue?: string | null,
   ): void;
-  markVectorSync(id: string, synced: boolean): void;
+  markVectorSync(id: string, synced: boolean, options?: { allowDuringLifecycle?: boolean }): void;
+  markAllVectorsSyncState(synced: boolean, options?: { allowDuringLifecycle?: boolean }): number;
   recordAccessBatch(updates: AccessUpdate[]): void;
   listExpiredMemories(nowIso: string, tier?: RetentionTier): MemoryRecordWithoutEmbedding[];
   listExpiringMemories(nowIso: string, untilIso: string, limit: number): MemoryRecordWithoutEmbedding[];
@@ -79,6 +80,7 @@ export interface SqliteStorage {
   getTierStats(): TierStats[];
   countArchivedMemories(): number;
   countUnsyncedVectors(): number;
+  listMemoriesNeedingVectorSync(limit: number, cursor?: string): MemoryRecordWithoutEmbedding[];
   archiveMemory(memory: MemoryRecordWithoutEmbedding, expiredAt: string): void;
   listArchive(limit: number): ArchiveRecord[];
   searchArchive(query: string, limit: number): ArchiveRecord[];
@@ -107,6 +109,7 @@ export interface SqliteStorage {
   beginLifecycleOperation(reason: string): void;
   endLifecycleOperation(reason?: string): void;
   isLifecycleOperationInProgress(): boolean;
+  getLifecycleOperation(): string | null;
   getMemoriesByIds(ids: string[]): MemoryRecordWithoutEmbedding[];
   listMemoryIdsInCollection(namespace: string, collection: string): string[];
   listCategoryHeaders(): CategoryHeader[];
@@ -564,10 +567,25 @@ export class SqliteStore implements SqliteStorage {
     this.markDirty();
   }
 
-  markVectorSync(id: string, synced: boolean): void {
-    this.assertMutableAllowed();
+  markVectorSync(id: string, synced: boolean, options?: { allowDuringLifecycle?: boolean }): void {
+    if (!options?.allowDuringLifecycle) {
+      this.assertMutableAllowed();
+    }
     this.db.run(`UPDATE memories SET vector_synced = ? WHERE id = ?`, [synced ? 1 : 0, id]);
     this.markDirty();
+  }
+
+  markAllVectorsSyncState(synced: boolean, options?: { allowDuringLifecycle?: boolean }): number {
+    if (!options?.allowDuringLifecycle) {
+      this.assertMutableAllowed();
+    }
+    const affected = synced ? this.countUnsyncedVectors() : this.countMemories();
+    if (affected === 0) {
+      return 0;
+    }
+    this.db.run(`UPDATE memories SET vector_synced = ? WHERE archived = 0`, [synced ? 1 : 0]);
+    this.markDirty();
+    return affected;
   }
 
   recordAccessBatch(
@@ -653,6 +671,26 @@ export class SqliteStore implements SqliteStorage {
     const row = stmt.getAsObject() as { cnt: number };
     stmt.free();
     return row.cnt;
+  }
+
+  listMemoriesNeedingVectorSync(limit: number, cursor?: string): MemoryRecordWithoutEmbedding[] {
+    let sql = `SELECT * FROM memories WHERE archived = 0 AND vector_synced = 0`;
+    const params: SqlParams = [];
+    if (cursor) {
+      const sepIdx = cursor.indexOf('|');
+      if (sepIdx !== -1) {
+        const cursorTime = cursor.substring(0, sepIdx);
+        const cursorId = cursor.substring(sepIdx + 1);
+        sql += ` AND (created_at > ? OR (created_at = ? AND id > ?))`;
+        params.push(cursorTime, cursorTime, cursorId);
+      } else {
+        sql += ` AND created_at > ?`;
+        params.push(cursor);
+      }
+    }
+    sql += ` ORDER BY created_at ASC, id ASC LIMIT ?`;
+    params.push(limit);
+    return this.queryMemories(sql, params);
   }
 
   archiveMemory(memory: MemoryRecordWithoutEmbedding, expiredAt: string): void {
@@ -992,6 +1030,10 @@ export class SqliteStore implements SqliteStorage {
 
   isLifecycleOperationInProgress(): boolean {
     return this.lifecycleOperation !== null;
+  }
+
+  getLifecycleOperation(): string | null {
+    return this.lifecycleOperation;
   }
 
   getMemoriesByIds(ids: string[]): MemoryRecordWithoutEmbedding[] {

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -1,40 +1,60 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleTool, type ToolContext } from './index.js';
+import type { BrainErrorEnvelope } from '../errors/index.js';
+import type { StorageManager } from '../storage/index.js';
+import type { EmbeddingProvider } from '../embedding/index.js';
+import type { WritePipeline } from '../pipeline/index.js';
+import type { SearchService } from '../search/index.js';
+import type { BackupService } from '../backup/index.js';
+import type { HealthService } from '../health/index.js';
+import type { MetricsCollector } from '../health/metrics.js';
+import type pino from 'pino';
+
+type CollectionDeleteResult = { ok: true; deleted_memory_count: number };
+type ToolResult = CollectionDeleteResult | BrainErrorEnvelope;
+type TestStorage = StorageManager & {
+  deleteCollectionData: ReturnType<typeof vi.fn>;
+  countMemoriesInCollection: ReturnType<typeof vi.fn>;
+  logAudit: ReturnType<typeof vi.fn>;
+};
 
 describe('collections delete semantics', () => {
   let ctx: ToolContext;
+  let storage: TestStorage;
 
   beforeEach(() => {
+    storage = {
+      sqlite: {
+        listCollections: vi.fn(() => []),
+        createCollection: vi.fn(),
+        flushIfDirty: vi.fn(),
+        getCollection: vi.fn(() => ({ name: 'general' })),
+        deleteCollection: vi.fn(() => true),
+        countMemories: vi.fn(() => 0),
+      },
+      countMemoriesInCollection: vi.fn(() => 3),
+      deleteCollectionData: vi.fn(async () => ({ deleted: 3, ids: ['a', 'b', 'c'] })),
+      logAudit: vi.fn(),
+    } as unknown as TestStorage;
+
     ctx = {
-      config: {} as any,
-      storage: {
-        sqlite: {
-          listCollections: vi.fn(() => []),
-          createCollection: vi.fn(),
-          flushIfDirty: vi.fn(),
-          getCollection: vi.fn(() => ({ name: 'general' })),
-          deleteCollection: vi.fn(() => true),
-          countMemories: vi.fn(() => 0),
-        },
-        countMemoriesInCollection: vi.fn(() => 3),
-        deleteCollectionData: vi.fn(async () => ({ deleted: 3, ids: ['a', 'b', 'c'] })),
-        logAudit: vi.fn(),
-      } as any,
-      embedding: { model: 'm', dimensions: 1 } as any,
-      pipeline: {} as any,
-      search: {} as any,
-      backup: {} as any,
-      health: {} as any,
-      metrics: { incCounter: vi.fn(), recordHistogram: vi.fn(), setGauge: vi.fn() } as any,
-      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any,
+      config: {} as ToolContext['config'],
+      storage,
+      embedding: { model: 'm', dimensions: 1 } as EmbeddingProvider,
+      pipeline: {} as WritePipeline,
+      search: {} as SearchService,
+      backup: {} as BackupService,
+      health: {} as HealthService,
+      metrics: { incCounter: vi.fn(), recordHistogram: vi.fn(), setGauge: vi.fn() } as unknown as MetricsCollector,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as pino.Logger,
     };
   });
 
   it('rejects deleting non-empty collection without force', async () => {
-    const result = await handleTool(ctx, 'collections', { action: 'delete', name: 'general' }, 'c1') as any;
+    const result = await handleTool(ctx, 'collections', { action: 'delete', name: 'general' }, 'c1') as ToolResult;
     expect(result.error.code).toBe('CONFLICT');
-    expect((ctx.storage as any).deleteCollectionData).not.toHaveBeenCalled();
-    expect((ctx.storage as any).sqlite.deleteCollection).not.toHaveBeenCalled();
+    expect(storage.deleteCollectionData).not.toHaveBeenCalled();
+    expect(storage.sqlite.deleteCollection).not.toHaveBeenCalled();
   });
 
   it('force deletes collection and returns deleted memory count', async () => {
@@ -43,33 +63,33 @@ describe('collections delete semantics', () => {
       namespace: 'global',
       name: 'general',
       force: true,
-    }, 'c1') as any;
+    }, 'c1') as ToolResult;
 
     expect(result.ok).toBe(true);
     expect(result.deleted_memory_count).toBe(3);
-    expect((ctx.storage as any).deleteCollectionData).toHaveBeenCalledWith('global', 'general');
-    expect((ctx.storage as any).sqlite.deleteCollection).toHaveBeenCalledWith('global', 'general');
-    expect((ctx.storage as any).logAudit).toHaveBeenCalledTimes(3);
-    expect((ctx.metrics as any).setGauge).toHaveBeenCalled();
+    expect(storage.deleteCollectionData).toHaveBeenCalledWith('global', 'general');
+    expect(storage.sqlite.deleteCollection).toHaveBeenCalledWith('global', 'general');
+    expect(storage.logAudit).toHaveBeenCalledTimes(3);
+    expect(ctx.metrics.setGauge).toHaveBeenCalled();
   });
 
   it('deletes empty collection without force', async () => {
-    (ctx.storage as any).countMemoriesInCollection = vi.fn(() => 0);
+    storage.countMemoriesInCollection = vi.fn(() => 0);
 
     const result = await handleTool(ctx, 'collections', {
       action: 'delete',
       namespace: 'global',
       name: 'general',
-    }, 'c1') as any;
+    }, 'c1') as ToolResult;
 
     expect(result.ok).toBe(true);
     expect(result.deleted_memory_count).toBe(0);
-    expect((ctx.storage as any).deleteCollectionData).not.toHaveBeenCalled();
-    expect((ctx.storage as any).sqlite.deleteCollection).toHaveBeenCalledWith('global', 'general');
+    expect(storage.deleteCollectionData).not.toHaveBeenCalled();
+    expect(storage.sqlite.deleteCollection).toHaveBeenCalledWith('global', 'general');
   });
 
   it('surfaces collection cleanup failures instead of silently succeeding', async () => {
-    (ctx.storage as any).deleteCollectionData = vi.fn(async () => {
+    storage.deleteCollectionData = vi.fn(async () => {
       throw new Error('qdrant unavailable');
     });
 
@@ -78,9 +98,9 @@ describe('collections delete semantics', () => {
       namespace: 'global',
       name: 'general',
       force: true,
-    }, 'c1') as any;
+    }, 'c1') as ToolResult;
 
     expect(result.error.code).toBe('INTERNAL');
-    expect((ctx.storage as any).sqlite.deleteCollection).not.toHaveBeenCalled();
+    expect(storage.sqlite.deleteCollection).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -53,7 +53,7 @@ export async function handleTool(
   try {
     const result = await dispatch(ctx, toolName, args, clientId);
     const duration = Date.now() - start;
-    ctx.metrics.recordHistogram('bhgbrain_tool_duration_seconds', duration / 1000);
+    ctx.metrics.recordHistogram('bhgbrain_tool_handler_ms', duration);
     ctx.logger.info({ event: 'tool_call', tool: toolName, duration_ms: duration, client_id: clientId });
     return result;
   } catch (err) {

--- a/src/transport/http.test.ts
+++ b/src/transport/http.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AddressInfo } from 'node:net';
+import type { BrainConfig } from '../config/index.js';
+
+const handleToolMock = vi.fn();
+
+vi.mock('../tools/index.js', () => ({
+  handleTool: handleToolMock,
+}));
+
+describe('createHttpServer', () => {
+  function createConfig(metricsEnabled = false, authRequired = true): BrainConfig {
+    return {
+      data_dir: 'test-data',
+      embedding: { provider: 'openai', model: 'test-model', api_key_env: 'OPENAI_API_KEY', dimensions: 3 },
+      qdrant: { mode: 'embedded', embedded_path: './qdrant', external_url: null, api_key_env: null },
+      transport: {
+        http: { enabled: true, host: '127.0.0.1', port: 3721, bearer_token_env: 'BHGBRAIN_TOKEN' },
+        stdio: { enabled: true },
+      },
+      defaults: {
+        namespace: 'global',
+        collection: 'general',
+        recall_limit: 5,
+        min_score: 0.6,
+        auto_inject_limit: 10,
+        max_response_chars: 50000,
+      },
+      retention: {
+        decay_after_days: 180,
+        max_db_size_gb: 2,
+        max_memories: 500000,
+        warn_at_percent: 80,
+        tier_ttl: { T0: null, T1: 365, T2: 90, T3: 30 },
+        tier_budgets: { T0: null, T1: 100000, T2: 200000, T3: 200000 },
+        auto_promote_access_threshold: 5,
+        sliding_window_enabled: true,
+        archive_before_delete: true,
+        cleanup_schedule: '0 2 * * *',
+        pre_expiry_warning_days: 7,
+        compaction_deleted_threshold: 0.1,
+      },
+      deduplication: { enabled: true, similarity_threshold: 0.92 },
+      resilience: {
+        circuit_breaker: {
+          failure_threshold: 1,
+          open_window_ms: 30000,
+          half_open_probe_count: 1,
+        },
+      },
+      search: { hybrid_weights: { semantic: 0.7, fulltext: 0.3 } },
+      security: {
+        require_loopback_http: true,
+        allow_unauthenticated_http: !authRequired,
+        log_redaction: true,
+        rate_limit_rpm: 100,
+        max_request_size_bytes: 1048576,
+      },
+      auto_inject: { max_chars: 30000, max_tokens: null },
+      observability: { metrics_enabled: metricsEnabled, structured_logging: true, log_level: 'info' },
+      pipeline: {
+        extraction_enabled: true,
+        extraction_model: 'gpt-4o-mini',
+        extraction_model_env: 'BHGBRAIN_EXTRACTION_API_KEY',
+        fallback_to_threshold_dedup: true,
+      },
+      auto_summarize: true,
+    };
+  }
+
+  async function startServer(config: BrainConfig, overrides?: {
+    health?: { check: () => Promise<unknown> };
+    metrics?: Partial<{
+      getMetrics: () => Array<{ name: string; value: number }>;
+      incCounter: (name: string, amount?: number) => void;
+      setGauge: (name: string, value: number) => void;
+      recordHistogram: (name: string, value: number) => void;
+    }>;
+    resources?: { handle: (uri: string) => Promise<unknown> };
+  }) {
+    process.env.BHGBRAIN_TOKEN = 'secret-token';
+    handleToolMock.mockClear();
+
+    const { createHttpServer } = await import('./http.js');
+    const logger = {
+      warn: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const defaultMetrics = {
+      getMetrics: vi.fn(() => []),
+      incCounter: vi.fn(),
+      setGauge: vi.fn(),
+      recordHistogram: vi.fn(),
+    };
+    const ctx = {
+      health: overrides?.health ?? { check: vi.fn(async () => ({ status: 'healthy' })) },
+      metrics: { ...defaultMetrics, ...overrides?.metrics },
+    };
+    const resources = overrides?.resources ?? { handle: vi.fn(async (uri: string) => ({ uri })) };
+
+    const app = createHttpServer(
+      config,
+      ctx as never,
+      resources as never,
+      logger as never,
+    );
+    const server = await new Promise<import('node:http').Server>((resolve) => {
+      const instance = app.listen(0, '127.0.0.1', () => resolve(instance));
+    });
+    const address = server.address() as AddressInfo;
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+
+    return { baseUrl, server, resources };
+  }
+
+  async function closeServer(server: import('node:http').Server) {
+    server.closeIdleConnections?.();
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => error ? reject(error) : resolve()),
+    );
+  }
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    delete process.env.BHGBRAIN_TOKEN;
+  });
+
+  it('returns health without auth and uses 200/503 based on status', async () => {
+    const healthy = await startServer(createConfig(false, true), {
+      health: { check: vi.fn(async () => ({ status: 'healthy' })) },
+    });
+    const healthyResponse = await fetch(`${healthy.baseUrl}/health`);
+    expect(healthyResponse.status).toBe(200);
+    await healthyResponse.json();
+    await closeServer(healthy.server);
+
+    const unhealthy = await startServer(createConfig(false, true), {
+      health: { check: vi.fn(async () => ({ status: 'unhealthy' })) },
+    });
+    const unhealthyResponse = await fetch(`${unhealthy.baseUrl}/health`);
+    expect(unhealthyResponse.status).toBe(503);
+    await unhealthyResponse.json();
+    await closeServer(unhealthy.server);
+  }, 15000);
+
+  it('rejects tool calls without or with invalid auth', async () => {
+    const { baseUrl, server } = await startServer(createConfig(false, true));
+
+    const missingAuth = await fetch(`${baseUrl}/tool/remember`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'hello' }),
+    });
+    expect(missingAuth.status).toBe(401);
+
+    const invalidAuth = await fetch(`${baseUrl}/tool/remember`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer wrong-token',
+      },
+      body: JSON.stringify({ content: 'hello' }),
+    });
+    expect(invalidAuth.status).toBe(401);
+
+    await closeServer(server);
+  });
+
+  it('calls handleTool and resources when authorized', async () => {
+    handleToolMock.mockResolvedValue({ ok: true });
+    const resourcesHandle = vi.fn(async () => ({ resource: true }));
+    const { baseUrl, server } = await startServer(createConfig(false, true), {
+      resources: { handle: resourcesHandle },
+    });
+
+    const toolResponse = await fetch(`${baseUrl}/tool/remember`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer secret-token',
+        'x-client-id': 'client-1',
+      },
+      body: JSON.stringify({ content: 'hello' }),
+    });
+    expect(toolResponse.status).toBe(200);
+    expect(await toolResponse.json()).toEqual({ ok: true });
+    expect(handleToolMock).toHaveBeenCalledWith(expect.anything(), 'remember', { content: 'hello' }, 'client-1');
+
+    const missingUri = await fetch(`${baseUrl}/resource`, {
+      headers: { 'Authorization': 'Bearer secret-token' },
+    });
+    expect(missingUri.status).toBe(400);
+
+    const resourceResponse = await fetch(`${baseUrl}/resource?uri=memory://list`, {
+      headers: { 'Authorization': 'Bearer secret-token' },
+    });
+    expect(resourceResponse.status).toBe(200);
+    expect(await resourceResponse.json()).toEqual({ resource: true });
+    expect(resourcesHandle).toHaveBeenCalledWith('memory://list');
+
+    await closeServer(server);
+  });
+
+  it('serves metrics only when enabled', async () => {
+    const disabled = await startServer(createConfig(false, true));
+    const disabledResponse = await fetch(`${disabled.baseUrl}/metrics`, {
+      headers: { 'Authorization': 'Bearer secret-token' },
+    });
+    expect(disabledResponse.status).toBe(404);
+    await disabledResponse.text();
+    await closeServer(disabled.server);
+
+    const enabled = await startServer(createConfig(true, true), {
+      metrics: {
+        getMetrics: vi.fn(() => [
+          { name: 'bhgbrain_tool_handler_ms_p95', value: 12 },
+          { name: 'search_total_ms_p95', value: 5 },
+        ]),
+      },
+    });
+    const enabledResponse = await fetch(`${enabled.baseUrl}/metrics`, {
+      headers: { 'Authorization': 'Bearer secret-token' },
+    });
+    expect(enabledResponse.status).toBe(200);
+    expect(await enabledResponse.text()).toContain('bhgbrain_tool_handler_ms_p95 12');
+    await closeServer(enabled.server);
+  });
+});

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -58,6 +58,7 @@ export function createHttpServer(
   // Metrics endpoint (if enabled)
   if (config.observability.metrics_enabled) {
     app.get('/metrics', (_req, res) => {
+      // Histogram families emit `_avg`, `_p50`, `_p95`, `_p99`, and `_count` lines.
       const metrics = ctx.metrics.getMetrics();
       const lines = metrics.map(m => `${m.name} ${m.value}`);
       res.type('text/plain').send(lines.join('\n'));

--- a/src/transport/middleware.test.ts
+++ b/src/transport/middleware.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createAuthMiddleware, createRateLimitMiddleware, resetRateLimitStateForTests, validateExternalAuthBinding } from './middleware.js';
+import type { BrainConfig } from '../config/index.js';
+import type { MetricsCollector } from '../health/metrics.js';
+import type pino from 'pino';
+import type { NextFunction, Request, Response } from 'express';
+
+type ResponseDouble = Pick<Response, 'status' | 'json' | 'setHeader'>;
+
+function createResponseDouble(): ResponseDouble {
+  const response: Partial<ResponseDouble> = {};
+  response.status = vi.fn(() => response as ResponseDouble);
+  response.json = vi.fn();
+  response.setHeader = vi.fn();
+  return response as ResponseDouble;
+}
 
 describe('transport middleware hardening', () => {
   beforeEach(() => {
@@ -9,14 +23,15 @@ describe('transport middleware hardening', () => {
   it('bypasses auth for /health even when token is configured', () => {
     process.env.BHGBRAIN_TOKEN = 'secret-token';
 
-    const logger = { warn: vi.fn() } as any;
-    const middleware = createAuthMiddleware({
+    const logger = { warn: vi.fn() } as unknown as pino.Logger;
+    const config = {
       transport: { http: { bearer_token_env: 'BHGBRAIN_TOKEN' } },
-    } as any, logger);
+    } as unknown as BrainConfig;
+    const middleware = createAuthMiddleware(config, logger);
 
-    const req = { path: '/health', headers: {} } as any;
-    const res = { status: vi.fn(() => res), json: vi.fn() } as any;
-    const next = vi.fn();
+    const req = { path: '/health', headers: {} } as unknown as Request;
+    const res = createResponseDouble() as unknown as Response;
+    const next = vi.fn() as unknown as NextFunction;
 
     middleware(req, res, next);
 
@@ -25,14 +40,15 @@ describe('transport middleware hardening', () => {
   });
 
   it('rate limits by trusted identity rather than x-client-id header', () => {
-    const metrics = { setGauge: vi.fn(), incCounter: vi.fn() } as any;
-    const logger = { warn: vi.fn() } as any;
-    const middleware = createRateLimitMiddleware({ security: { rate_limit_rpm: 1 } } as any, logger, metrics);
+    const metrics = { setGauge: vi.fn(), incCounter: vi.fn() } as unknown as MetricsCollector;
+    const logger = { warn: vi.fn() } as unknown as pino.Logger;
+    const config = { security: { rate_limit_rpm: 1 } } as unknown as BrainConfig;
+    const middleware = createRateLimitMiddleware(config, logger, metrics);
 
-    const req1 = { ip: '10.0.0.1', headers: { 'x-client-id': 'a' } } as any;
-    const req2 = { ip: '10.0.0.1', headers: { 'x-client-id': 'b' } } as any;
-    const res1 = { status: vi.fn(() => res1), json: vi.fn(), setHeader: vi.fn() } as any;
-    const res2 = { status: vi.fn(() => res2), json: vi.fn(), setHeader: vi.fn() } as any;
+    const req1 = { ip: '10.0.0.1', headers: { 'x-client-id': 'a' } } as unknown as Request;
+    const req2 = { ip: '10.0.0.1', headers: { 'x-client-id': 'b' } } as unknown as Request;
+    const res1 = createResponseDouble() as unknown as Response;
+    const res2 = createResponseDouble() as unknown as Response;
 
     middleware(req1, res1, vi.fn());
     middleware(req2, res2, vi.fn());
@@ -42,19 +58,20 @@ describe('transport middleware hardening', () => {
   });
 
   it('evicts expired buckets over time', () => {
-    const metrics = { setGauge: vi.fn(), incCounter: vi.fn() } as any;
-    const middleware = createRateLimitMiddleware({ security: { rate_limit_rpm: 100 } } as any, undefined, metrics);
+    const metrics = { setGauge: vi.fn(), incCounter: vi.fn() } as unknown as MetricsCollector;
+    const config = { security: { rate_limit_rpm: 100 } } as unknown as BrainConfig;
+    const middleware = createRateLimitMiddleware(config, undefined, metrics);
 
     const now = vi.spyOn(Date, 'now');
     now.mockReturnValue(0);
 
-    const req1 = { ip: '10.0.0.2', headers: {} } as any;
-    const res1 = { status: vi.fn(() => res1), json: vi.fn(), setHeader: vi.fn() } as any;
+    const req1 = { ip: '10.0.0.2', headers: {} } as unknown as Request;
+    const res1 = createResponseDouble() as unknown as Response;
     middleware(req1, res1, vi.fn());
 
     now.mockReturnValue(61_000);
-    const req2 = { ip: '10.0.0.3', headers: {} } as any;
-    const res2 = { status: vi.fn(() => res2), json: vi.fn(), setHeader: vi.fn() } as any;
+    const req2 = { ip: '10.0.0.3', headers: {} } as unknown as Request;
+    const res2 = createResponseDouble() as unknown as Response;
     middleware(req2, res2, vi.fn());
 
     const lastGaugeCall = metrics.setGauge.mock.calls[metrics.setGauge.mock.calls.length - 1];
@@ -77,7 +94,7 @@ describe('fail-closed auth startup policy', () => {
     const config = {
       transport: { http: { host: '0.0.0.0', bearer_token_env: 'BHGBRAIN_TOKEN' } },
       security: { require_loopback_http: false, allow_unauthenticated_http: false },
-    } as any;
+    } as unknown as BrainConfig;
 
     expect(() => validateExternalAuthBinding(config)).toThrow('SECURITY');
   });
@@ -87,18 +104,18 @@ describe('fail-closed auth startup policy', () => {
     const config = {
       transport: { http: { host: '0.0.0.0', bearer_token_env: 'BHGBRAIN_TOKEN' } },
       security: { require_loopback_http: false, allow_unauthenticated_http: false },
-    } as any;
+    } as unknown as BrainConfig;
 
     expect(() => validateExternalAuthBinding(config)).not.toThrow();
   });
 
   it('allows unauthenticated when explicitly opted in and logs warning', () => {
     delete process.env.BHGBRAIN_TOKEN;
-    const logger = { warn: vi.fn() } as any;
+    const logger = { warn: vi.fn() } as unknown as pino.Logger;
     const config = {
       transport: { http: { host: '0.0.0.0', bearer_token_env: 'BHGBRAIN_TOKEN' } },
       security: { require_loopback_http: false, allow_unauthenticated_http: true },
-    } as any;
+    } as unknown as BrainConfig;
 
     expect(() => validateExternalAuthBinding(config, logger)).not.toThrow();
     expect(logger.warn).toHaveBeenCalledWith(
@@ -111,7 +128,7 @@ describe('fail-closed auth startup policy', () => {
     const config = {
       transport: { http: { host: '127.0.0.1', bearer_token_env: 'BHGBRAIN_TOKEN' } },
       security: { require_loopback_http: true, allow_unauthenticated_http: false },
-    } as any;
+    } as unknown as BrainConfig;
 
     expect(() => validateExternalAuthBinding(config)).not.toThrow();
   });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,15 +1,22 @@
 declare module 'sql.js' {
+  type SqlValue = string | number | null | Uint8Array;
+  type SqlParams = SqlValue[];
+  type SqlObject = Record<string, SqlValue | undefined>;
+  interface SqlJsInitConfig {
+    locateFile?: (file: string) => string;
+  }
+
   interface Database {
-    run(sql: string, params?: any[]): void;
+    run(sql: string, params?: SqlParams): void;
     prepare(sql: string): Statement;
     export(): Uint8Array;
     close(): void;
   }
 
   interface Statement {
-    bind(params?: any[]): void;
+    bind(params?: SqlParams): void;
     step(): boolean;
-    getAsObject(): Record<string, any>;
+    getAsObject(): SqlObject;
     free(): void;
   }
 
@@ -17,6 +24,6 @@ declare module 'sql.js' {
     Database: new (data?: ArrayLike<number>) => Database;
   }
 
-  export default function initSqlJs(config?: any): Promise<SqlJsStatic>;
+  export default function initSqlJs(config?: SqlJsInitConfig): Promise<SqlJsStatic>;
   export type { Database, Statement, SqlJsStatic };
 }

--- a/temp_percentile.patch
+++ b/temp_percentile.patch
@@ -1,0 +1,204 @@
+diff --git a/README.md b/README.md
+--- a/README.md
++++ b/README.md
+@@ -1305,8 +1305,13 @@ Returns plain-text key-value metrics (Prometheus-compatible format):
+ | Metric | Type | Description |
+ |---|---|---|
+ | `bhgbrain_tool_calls_total` | counter | Total tool invocations |
+-| `bhgbrain_tool_duration_seconds_avg` | histogram | Average tool call duration |
+-| `bhgbrain_tool_duration_seconds_count` | counter | Number of tool call duration samples |
++| `bhgbrain_tool_handler_ms_avg` | histogram | Average tool handler latency in milliseconds |
++| `bhgbrain_tool_handler_ms_p50` | histogram | 50th percentile tool handler latency |
++| `bhgbrain_tool_handler_ms_p95` | histogram | 95th percentile tool handler latency |
++| `bhgbrain_tool_handler_ms_p99` | histogram | 99th percentile tool handler latency |
++| `bhgbrain_tool_handler_ms_count` | counter | Number of tool handler latency samples |
++| `embedding_embed_batch_ms_p95` | histogram | 95th percentile embedding batch latency |
++| `search_total_ms_p95` | histogram | 95th percentile end-to-end search latency |
+ | `bhgbrain_memory_count` | gauge | Current total memory count (updated on write/delete) |
+ | `bhgbrain_rate_limit_buckets` | gauge | Active rate limit tracking buckets |
+ | `bhgbrain_rate_limited_total` | counter | Total rate-limited requests |
+@@ -1943,7 +1948,7 @@ The backup is stored in the data directory (`%LOCALAPPDATA%\BHGBrain\` on Window
+ ### Operational Observability
+ 
+ - **Bounded metrics:** Histogram values use a bounded circular buffer (last 1000 samples).
+-- **Metric semantics:** Histogram metrics emit `_avg` and `_count` suffixes.
++- **Metric semantics:** Histogram metrics emit `_avg`, `_p50`, `_p95`, `_p99`, and `_count` suffixes.
+ - **Atomic writes:** Database and backup file writes use write-to-temp-then-rename to prevent truncated partial files on crash.
+ - **Deferred flush:** Read-path access metadata (touch counts) uses bounded async batching (5s window) instead of synchronous full-database flushes per request.
+ - **Cross-store consistency:** SQLite updates are rolled back if the corresponding Qdrant operation fails.
+diff --git a/src/embedding/index.ts b/src/embedding/index.ts
+--- a/src/embedding/index.ts
++++ b/src/embedding/index.ts
+@@ -1,4 +1,5 @@
+ import type { BrainConfig } from '../config/index.js';
++import type { MetricsCollector } from '../health/metrics.js';
+ import { embeddingUnavailable } from '../errors/index.js';
+@@ -14,7 +15,10 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
+   private apiKey: string;
+   private baseUrl = 'https://api.openai.com/v1';
+ 
+-  constructor(config: BrainConfig) {
++  constructor(
++    config: BrainConfig,
++    private readonly metrics?: MetricsCollector,
++  ) {
+     this.model = config.embedding.model;
+     this.dimensions = config.embedding.dimensions;
+     const key = process.env[config.embedding.api_key_env];
+@@ -29,6 +33,7 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
+   }
+ 
+   async embedBatch(texts: string[]): Promise<number[][]> {
++    const start = Date.now();
+     let response: Response;
+     try {
+       response = await fetch(`${this.baseUrl}/embeddings`, {
+@@ -45,6 +50,8 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
+       });
+     } catch (err) {
+       throw embeddingUnavailable(`Embedding provider unreachable: ${(err as Error).message}`);
++    } finally {
++      this.metrics?.recordHistogram('embedding_embed_batch_ms', Date.now() - start);
+     }
+ 
+     if (!response.ok) {
+@@ -89,11 +96,14 @@ export class DegradedEmbeddingProvider implements EmbeddingProvider {
+   }
+ }
+ 
+-export function createEmbeddingProvider(config: BrainConfig): EmbeddingProvider {
++export function createEmbeddingProvider(
++  config: BrainConfig,
++  options?: { metrics?: MetricsCollector },
++): EmbeddingProvider {
+   switch (config.embedding.provider) {
+     case 'openai':
+       try {
+-        return new OpenAIEmbeddingProvider(config);
++        return new OpenAIEmbeddingProvider(config, options?.metrics);
+       } catch {
+         // Missing credentials: start in degraded mode
+         return new DegradedEmbeddingProvider(config);
+diff --git a/src/health/metrics.ts b/src/health/metrics.ts
+--- a/src/health/metrics.ts
++++ b/src/health/metrics.ts
+@@ -7,6 +7,16 @@ interface MetricEntry {
+   labels?: Record<string, string>;
+ }
+ 
++export function computePercentile(sortedValues: number[], p: number): number {
++  if (sortedValues.length === 0) {
++    return 0;
++  }
++
++  const rank = Math.ceil((p / 100) * sortedValues.length);
++  const index = Math.min(sortedValues.length - 1, Math.max(0, rank - 1));
++  return sortedValues[index] ?? 0;
++}
++
+ /** Bounded circular buffer for histogram values */
+ class BoundedBuffer {
+   private buffer: number[];
+@@ -72,7 +82,11 @@ export class MetricsCollector {
+       const count = vals.length;
+       const sum = count > 0 ? vals.reduce((a, b) => a + b, 0) : 0;
+       const avg = count > 0 ? sum / count : 0;
++      const sortedValues = [...vals].sort((a, b) => a - b);
+       entries.push({ name: `${name}_avg`, type: 'histogram', value: avg });
++      entries.push({ name: `${name}_p50`, type: 'histogram', value: computePercentile(sortedValues, 50) });
++      entries.push({ name: `${name}_p95`, type: 'histogram', value: computePercentile(sortedValues, 95) });
++      entries.push({ name: `${name}_p99`, type: 'histogram', value: computePercentile(sortedValues, 99) });
+       entries.push({ name: `${name}_count`, type: 'counter', value: count });
+     }
+     for (const [name, value] of this.gauges) {
+diff --git a/src/index.ts b/src/index.ts
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -37,16 +37,17 @@ async function main() {
+   const sqlite = new SqliteStore(config.data_dir!);
+   await sqlite.init();
+ 
++  const metrics = new MetricsCollector(config);
+   const qdrant = new QdrantStore(config);
+-  const embedding = createEmbeddingProvider(config);
++  const embedding = createEmbeddingProvider(config, { metrics });
+   const storage = new StorageManager(sqlite, qdrant, embedding);
+ 
+   // Initialize services
+   const pipeline = new WritePipeline(config, storage, embedding);
+-  const searchService = new SearchService(config, storage, embedding);
++  const searchService = new SearchService(config, storage, embedding, metrics);
+   const backupService = new BackupService(config, storage, logger);
+   const healthService = new HealthService(storage, embedding, config);
+-  const metrics = new MetricsCollector(config);
+ 
+   const ctx: ToolContext = {
+     config, storage, embedding, pipeline,
+diff --git a/src/search/index.ts b/src/search/index.ts
+--- a/src/search/index.ts
++++ b/src/search/index.ts
+@@ -2,6 +2,7 @@ import type { BrainConfig } from '../config/index.js';
+ import type { StorageManager } from '../storage/index.js';
+ import type { EmbeddingProvider } from '../embedding/index.js';
+ import type { SearchMode, SearchResult } from '../domain/types.js';
++import type { MetricsCollector } from '../health/metrics.js';
+ import { MemoryLifecycleService } from '../domain/lifecycle.js';
+ import { embeddingUnavailable, internal } from '../errors/index.js';
+@@ -20,6 +21,7 @@ export class SearchService {
+     private config: BrainConfig,
+     private storage: StorageManager,
+     private embedding: EmbeddingProvider,
++    private metrics?: MetricsCollector,
+   ) {
+     this.lifecycle = new MemoryLifecycleService(config);
+   }
+@@ -30,13 +32,20 @@ export class SearchService {
+     mode: SearchMode,
+     limit: number,
+   ): Promise<SearchResult[]> {
+-    switch (mode) {
+-      case 'semantic':
+-        return this.semanticSearch(query, namespace, collection, limit);
+-      case 'fulltext':
+-        return this.fulltextSearch(query, namespace, collection, limit);
+-      case 'hybrid':
+-        return this.hybridSearch(query, namespace, collection, limit);
++    const start = Date.now();
++    try {
++      switch (mode) {
++        case 'semantic':
++          return await this.semanticSearch(query, namespace, collection, limit);
++        case 'fulltext':
++          return this.fulltextSearch(query, namespace, collection, limit);
++        case 'hybrid':
++          return await this.hybridSearch(query, namespace, collection, limit);
++      }
++      const unsupportedMode: never = mode;
++      throw new Error(`Unsupported search mode: ${unsupportedMode}`);
++    } finally {
++      this.metrics?.recordHistogram('search_total_ms', Date.now() - start);
+     }
+   }
+diff --git a/src/tools/index.ts b/src/tools/index.ts
+--- a/src/tools/index.ts
++++ b/src/tools/index.ts
+@@ -48,7 +48,7 @@ export async function handleTool(
+   try {
+     const result = await dispatch(ctx, toolName, args, clientId);
+     const duration = Date.now() - start;
+-    ctx.metrics.recordHistogram('bhgbrain_tool_duration_seconds', duration / 1000);
++    ctx.metrics.recordHistogram('bhgbrain_tool_handler_ms', duration);
+     ctx.logger.info({ event: 'tool_call', tool: toolName, duration_ms: duration, client_id: clientId });
+     return result;
+   } catch (err) {
+diff --git a/src/transport/http.ts b/src/transport/http.ts
+--- a/src/transport/http.ts
++++ b/src/transport/http.ts
+@@ -52,6 +52,7 @@ export function createHttpServer(
+   // Metrics endpoint (if enabled)
+   if (config.observability.metrics_enabled) {
+     app.get('/metrics', (_req, res) => {
++      // Histogram families emit `_avg`, `_p50`, `_p95`, `_p99`, and `_count` lines.
+       const metrics = ctx.metrics.getMetrics();
+       const lines = metrics.map(m => `${m.name} ${m.value}`);
+       res.type('text/plain').send(lines.join('\n'));

--- a/temp_stage/embedding.head.ts
+++ b/temp_stage/embedding.head.ts
@@ -1,0 +1,114 @@
+import type { BrainConfig } from '../config/index.js';
+import { embeddingUnavailable } from '../errors/index.js';
+
+export interface EmbeddingProvider {
+  readonly model: string;
+  readonly dimensions: number;
+  embed(text: string): Promise<number[]>;
+  embedBatch(texts: string[]): Promise<number[][]>;
+  healthCheck(): Promise<boolean>;
+}
+
+export class OpenAIEmbeddingProvider implements EmbeddingProvider {
+  readonly model: string;
+  readonly dimensions: number;
+  private apiKey: string;
+  private baseUrl = 'https://api.openai.com/v1';
+
+  constructor(config: BrainConfig) {
+    this.model = config.embedding.model;
+    this.dimensions = config.embedding.dimensions;
+    const key = process.env[config.embedding.api_key_env];
+    if (!key) {
+      throw new Error(`Missing environment variable: ${config.embedding.api_key_env}`);
+    }
+    this.apiKey = key;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const results = await this.embedBatch([text]);
+    return results[0]!;
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseUrl}/embeddings`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: this.model,
+          input: texts,
+        }),
+      });
+    } catch (err) {
+      throw embeddingUnavailable(`Embedding provider unreachable: ${(err as Error).message}`);
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw embeddingUnavailable(`Embedding API error ${response.status}: ${body.slice(0, 200)}`);
+    }
+
+    const data = await response.json() as {
+      data: Array<{ embedding: number[]; index: number }>;
+    };
+
+    return data.data
+      .sort((a, b) => a.index - b.index)
+      .map(d => d.embedding);
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      await this.embed('health check');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Degraded embedding provider returned when credentials are unavailable.
+ * Allows the server to start but rejects embedding-dependent operations at request time.
+ */
+export class DegradedEmbeddingProvider implements EmbeddingProvider {
+  readonly model: string;
+  readonly dimensions: number;
+  readonly degraded = true;
+
+  constructor(config: BrainConfig) {
+    this.model = config.embedding.model;
+    this.dimensions = config.embedding.dimensions;
+  }
+
+  async embed(): Promise<number[]> {
+    throw embeddingUnavailable('Embedding provider is unavailable: missing API credentials');
+  }
+
+  async embedBatch(): Promise<number[][]> {
+    throw embeddingUnavailable('Embedding provider is unavailable: missing API credentials');
+  }
+
+  async healthCheck(): Promise<boolean> {
+    return false;
+  }
+}
+
+export function createEmbeddingProvider(config: BrainConfig): EmbeddingProvider {
+  switch (config.embedding.provider) {
+    case 'openai':
+      try {
+        return new OpenAIEmbeddingProvider(config);
+      } catch {
+        // Missing credentials: start in degraded mode
+        return new DegradedEmbeddingProvider(config);
+      }
+    default:
+      throw new Error(`Unknown embedding provider: ${config.embedding.provider}`);
+  }
+}

--- a/temp_stage/embedding.index.ts
+++ b/temp_stage/embedding.index.ts
@@ -1,0 +1,124 @@
+import type { BrainConfig } from '../config/index.js';
+import type { MetricsCollector } from '../health/metrics.js';
+import { embeddingUnavailable } from '../errors/index.js';
+
+export interface EmbeddingProvider {
+  readonly model: string;
+  readonly dimensions: number;
+  embed(text: string): Promise<number[]>;
+  embedBatch(texts: string[]): Promise<number[][]>;
+  healthCheck(): Promise<boolean>;
+}
+
+export class OpenAIEmbeddingProvider implements EmbeddingProvider {
+  readonly model: string;
+  readonly dimensions: number;
+  private apiKey: string;
+  private baseUrl = 'https://api.openai.com/v1';
+
+  constructor(
+    config: BrainConfig,
+    private readonly metrics?: MetricsCollector,
+  ) {
+    this.model = config.embedding.model;
+    this.dimensions = config.embedding.dimensions;
+    const key = process.env[config.embedding.api_key_env];
+    if (!key) {
+      throw new Error(`Missing environment variable: ${config.embedding.api_key_env}`);
+    }
+    this.apiKey = key;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const results = await this.embedBatch([text]);
+    return results[0]!;
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    const start = Date.now();
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseUrl}/embeddings`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: this.model,
+          input: texts,
+        }),
+      });
+    } catch (err) {
+      throw embeddingUnavailable(`Embedding provider unreachable: ${(err as Error).message}`);
+    } finally {
+      this.metrics?.recordHistogram('embedding_embed_batch_ms', Date.now() - start);
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw embeddingUnavailable(`Embedding API error ${response.status}: ${body.slice(0, 200)}`);
+    }
+
+    const data = await response.json() as {
+      data: Array<{ embedding: number[]; index: number }>;
+    };
+
+    return data.data
+      .sort((a, b) => a.index - b.index)
+      .map(d => d.embedding);
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      await this.embed('health check');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Degraded embedding provider returned when credentials are unavailable.
+ * Allows the server to start but rejects embedding-dependent operations at request time.
+ */
+export class DegradedEmbeddingProvider implements EmbeddingProvider {
+  readonly model: string;
+  readonly dimensions: number;
+  readonly degraded = true;
+
+  constructor(config: BrainConfig) {
+    this.model = config.embedding.model;
+    this.dimensions = config.embedding.dimensions;
+  }
+
+  async embed(): Promise<number[]> {
+    throw embeddingUnavailable('Embedding provider is unavailable: missing API credentials');
+  }
+
+  async embedBatch(): Promise<number[][]> {
+    throw embeddingUnavailable('Embedding provider is unavailable: missing API credentials');
+  }
+
+  async healthCheck(): Promise<boolean> {
+    return false;
+  }
+}
+
+export function createEmbeddingProvider(
+  config: BrainConfig,
+  options?: { metrics?: MetricsCollector },
+): EmbeddingProvider {
+  switch (config.embedding.provider) {
+    case 'openai':
+      try {
+        return new OpenAIEmbeddingProvider(config, options?.metrics);
+      } catch {
+        // Missing credentials: start in degraded mode
+        return new DegradedEmbeddingProvider(config);
+      }
+    default:
+      throw new Error(`Unknown embedding provider: ${config.embedding.provider}`);
+  }
+}

--- a/temp_stage/index.head.ts
+++ b/temp_stage/index.head.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import { loadConfig, ensureDataDir } from './config/index.js';
+import { SqliteStore } from './storage/sqlite.js';
+import { QdrantStore } from './storage/qdrant.js';
+import { StorageManager } from './storage/index.js';
+import { createEmbeddingProvider } from './embedding/index.js';
+import { WritePipeline } from './pipeline/index.js';
+import { SearchService } from './search/index.js';
+import { BackupService } from './backup/index.js';
+import { HealthService } from './health/index.js';
+import { MetricsCollector } from './health/metrics.js';
+import { createLogger } from './health/logger.js';
+import { ResourceHandler, MCP_RESOURCE_DEFINITIONS, MCP_RESOURCE_TEMPLATES } from './resources/index.js';
+import { handleTool, type ToolContext } from './tools/index.js';
+import { MCP_TOOL_DEFINITIONS } from './tools/schemas.js';
+import { createHttpServer } from './transport/http.js';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const isStdio = args.includes('--stdio');
+  const configPath = args.find(a => a.startsWith('--config='))?.split('=')[1];
+
+  const config = loadConfig(configPath);
+  ensureDataDir(config);
+
+  // When using stdio transport, pino must write to stderr — stdout is reserved for MCP JSON-RPC
+  const logger = createLogger(config, isStdio ? process.stderr : undefined);
+  logger.info({ event: 'startup', data_dir: config.data_dir });
+
+  // Initialize storage
+  const sqlite = new SqliteStore(config.data_dir!);
+  await sqlite.init();
+
+  const qdrant = new QdrantStore(config);
+  const embedding = createEmbeddingProvider(config);
+  const storage = new StorageManager(sqlite, qdrant, embedding);
+
+  // Initialize services
+  const pipeline = new WritePipeline(config, storage, embedding);
+  const searchService = new SearchService(config, storage, embedding);
+  const backupService = new BackupService(config, storage, logger);
+  const healthService = new HealthService(storage, embedding, config);
+  const metrics = new MetricsCollector(config);
+
+  const ctx: ToolContext = {
+    config, storage, embedding, pipeline,
+    search: searchService, backup: backupService,
+    health: healthService, metrics, logger,
+  };
+
+  const resources = new ResourceHandler(config, storage, searchService, healthService);
+
+  if (isStdio || !config.transport.http.enabled) {
+    // MCP stdio transport
+    const server = new Server(
+      { name: 'bhgbrain', version: '1.0.0' },
+      { capabilities: { tools: {}, resources: {} } },
+    );
+
+    server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: MCP_TOOL_DEFINITIONS,
+    }));
+
+    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: toolArgs } = request.params;
+      const result = await handleTool(ctx, name, toolArgs);
+
+      // Detect error envelopes and signal via MCP isError
+      const isError = result != null && typeof result === 'object' && 'error' in (result as any);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        ...(isError ? { isError: true } : {}),
+      };
+    });
+
+    server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+      resources: MCP_RESOURCE_DEFINITIONS.map(r => ({
+        uri: r.uri,
+        name: r.name,
+        description: r.description,
+        mimeType: 'application/json',
+      })),
+    }));
+
+    server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
+      resourceTemplates: MCP_RESOURCE_TEMPLATES.map(r => ({
+        uriTemplate: r.uriTemplate,
+        name: r.name,
+        description: r.description,
+        mimeType: 'application/json',
+      })),
+    }));
+
+    server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+      const { uri } = request.params;
+      const result = await resources.handle(uri);
+      return {
+        contents: [{
+          uri,
+          mimeType: 'application/json',
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    });
+
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    logger.info({ event: 'connected', transport: 'stdio' });
+  } else {
+    // HTTP transport
+    const app = createHttpServer(config, ctx, resources, logger);
+    const { host, port } = config.transport.http;
+
+    app.listen(port, host, () => {
+      logger.info({ event: 'listening', transport: 'http', host, port });
+      console.log(`BHGBrain server listening on http://${host}:${port}`);
+    });
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/temp_stage/index.ts
+++ b/temp_stage/index.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import { loadConfig, ensureDataDir } from './config/index.js';
+import { SqliteStore } from './storage/sqlite.js';
+import { QdrantStore } from './storage/qdrant.js';
+import { StorageManager } from './storage/index.js';
+import { createEmbeddingProvider } from './embedding/index.js';
+import { WritePipeline } from './pipeline/index.js';
+import { SearchService } from './search/index.js';
+import { BackupService } from './backup/index.js';
+import { HealthService } from './health/index.js';
+import { MetricsCollector } from './health/metrics.js';
+import { createLogger } from './health/logger.js';
+import { ResourceHandler, MCP_RESOURCE_DEFINITIONS, MCP_RESOURCE_TEMPLATES } from './resources/index.js';
+import { handleTool, type ToolContext } from './tools/index.js';
+import { MCP_TOOL_DEFINITIONS } from './tools/schemas.js';
+import { createHttpServer } from './transport/http.js';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const isStdio = args.includes('--stdio');
+  const configPath = args.find(a => a.startsWith('--config='))?.split('=')[1];
+
+  const config = loadConfig(configPath);
+  ensureDataDir(config);
+
+  // When using stdio transport, pino must write to stderr — stdout is reserved for MCP JSON-RPC
+  const logger = createLogger(config, isStdio ? process.stderr : undefined);
+  logger.info({ event: 'startup', data_dir: config.data_dir });
+
+  // Initialize storage
+  const sqlite = new SqliteStore(config.data_dir!);
+  await sqlite.init();
+
+  const metrics = new MetricsCollector(config);
+  const qdrant = new QdrantStore(config);
+  const embedding = createEmbeddingProvider(config, { metrics });
+  const storage = new StorageManager(sqlite, qdrant, embedding);
+
+  // Initialize services
+  const pipeline = new WritePipeline(config, storage, embedding);
+  const searchService = new SearchService(config, storage, embedding, metrics);
+  const backupService = new BackupService(config, storage, logger);
+  const healthService = new HealthService(storage, embedding, config);
+
+  const ctx: ToolContext = {
+    config, storage, embedding, pipeline,
+    search: searchService, backup: backupService,
+    health: healthService, metrics, logger,
+  };
+
+  const resources = new ResourceHandler(config, storage, searchService, healthService);
+
+  if (isStdio || !config.transport.http.enabled) {
+    // MCP stdio transport
+    const server = new Server(
+      { name: 'bhgbrain', version: '1.0.0' },
+      { capabilities: { tools: {}, resources: {} } },
+    );
+
+    server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: MCP_TOOL_DEFINITIONS,
+    }));
+
+    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: toolArgs } = request.params;
+      const result = await handleTool(ctx, name, toolArgs);
+
+      // Detect error envelopes and signal via MCP isError
+      const isError = result != null && typeof result === 'object' && 'error' in (result as any);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        ...(isError ? { isError: true } : {}),
+      };
+    });
+
+    server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+      resources: MCP_RESOURCE_DEFINITIONS.map(r => ({
+        uri: r.uri,
+        name: r.name,
+        description: r.description,
+        mimeType: 'application/json',
+      })),
+    }));
+
+    server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
+      resourceTemplates: MCP_RESOURCE_TEMPLATES.map(r => ({
+        uriTemplate: r.uriTemplate,
+        name: r.name,
+        description: r.description,
+        mimeType: 'application/json',
+      })),
+    }));
+
+    server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+      const { uri } = request.params;
+      const result = await resources.handle(uri);
+      return {
+        contents: [{
+          uri,
+          mimeType: 'application/json',
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    });
+
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    logger.info({ event: 'connected', transport: 'stdio' });
+  } else {
+    // HTTP transport
+    const app = createHttpServer(config, ctx, resources, logger);
+    const { host, port } = config.transport.http;
+
+    app.listen(port, host, () => {
+      logger.info({ event: 'listening', transport: 'http', host, port });
+      console.log(`BHGBrain server listening on http://${host}:${port}`);
+    });
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/temp_stage/mixed.patch
+++ b/temp_stage/mixed.patch
@@ -1,0 +1,131 @@
+diff --git a/src/embedding/index.ts b/src/embedding/index.ts
+index 2a2f568..8d48c7f 100644
+--- a/src/embedding/index.ts
++++ b/src/embedding/index.ts
+@@ -1,4 +1,5 @@
+ import type { BrainConfig } from '../config/index.js';
++import type { MetricsCollector } from '../health/metrics.js';
+ import { embeddingUnavailable } from '../errors/index.js';
+ 
+ export interface EmbeddingProvider {
+@@ -15,7 +16,10 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
+   private apiKey: string;
+   private baseUrl = 'https://api.openai.com/v1';
+ 
+-  constructor(config: BrainConfig) {
++  constructor(
++    config: BrainConfig,
++    private readonly metrics?: MetricsCollector,
++  ) {
+     this.model = config.embedding.model;
+     this.dimensions = config.embedding.dimensions;
+     const key = process.env[config.embedding.api_key_env];
+@@ -31,6 +35,7 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
+   }
+ 
+   async embedBatch(texts: string[]): Promise<number[][]> {
++    const start = Date.now();
+     let response: Response;
+     try {
+       response = await fetch(`${this.baseUrl}/embeddings`, {
+@@ -46,6 +51,8 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
+       });
+     } catch (err) {
+       throw embeddingUnavailable(`Embedding provider unreachable: ${(err as Error).message}`);
++    } finally {
++      this.metrics?.recordHistogram('embedding_embed_batch_ms', Date.now() - start);
+     }
+ 
+     if (!response.ok) {
+@@ -99,11 +106,14 @@ export class DegradedEmbeddingProvider implements EmbeddingProvider {
+   }
+ }
+ 
+-export function createEmbeddingProvider(config: BrainConfig): EmbeddingProvider {
++export function createEmbeddingProvider(
++  config: BrainConfig,
++  options?: { metrics?: MetricsCollector },
++): EmbeddingProvider {
+   switch (config.embedding.provider) {
+     case 'openai':
+       try {
+-        return new OpenAIEmbeddingProvider(config);
++        return new OpenAIEmbeddingProvider(config, options?.metrics);
+       } catch {
+         // Missing credentials: start in degraded mode
+         return new DegradedEmbeddingProvider(config);
+
+diff --git a/src/search/index.ts b/src/search/index.ts
+index c639eff..df31968 100644
+--- a/src/search/index.ts
++++ b/src/search/index.ts
+@@ -2,6 +2,7 @@ import type { BrainConfig } from '../config/index.js';
+ import type { StorageManager } from '../storage/index.js';
+ import type { EmbeddingProvider } from '../embedding/index.js';
+ import type { SearchMode, SearchResult } from '../domain/types.js';
++import type { MetricsCollector } from '../health/metrics.js';
+ import { MemoryLifecycleService } from '../domain/lifecycle.js';
+ import { embeddingUnavailable, internal } from '../errors/index.js';
+ 
+@@ -22,6 +23,7 @@ export class SearchService {
+     private config: BrainConfig,
+     private storage: StorageManager,
+     private embedding: EmbeddingProvider,
++    private metrics?: MetricsCollector,
+   ) {
+     this.lifecycle = new MemoryLifecycleService(config);
+   }
+@@ -33,13 +35,20 @@ export class SearchService {
+     mode: SearchMode,
+     limit: number,
+   ): Promise<SearchResult[]> {
+-    switch (mode) {
+-      case 'semantic':
+-        return this.semanticSearch(query, namespace, collection, limit);
+-      case 'fulltext':
+-        return this.fulltextSearch(query, namespace, collection, limit);
+-      case 'hybrid':
+-        return this.hybridSearch(query, namespace, collection, limit);
++    const start = Date.now();
++    try {
++      switch (mode) {
++        case 'semantic':
++          return await this.semanticSearch(query, namespace, collection, limit);
++        case 'fulltext':
++          return this.fulltextSearch(query, namespace, collection, limit);
++        case 'hybrid':
++          return await this.hybridSearch(query, namespace, collection, limit);
++      }
++      const unsupportedMode: never = mode;
++      throw new Error(`Unsupported search mode: ${unsupportedMode}`);
++    } finally {
++      this.metrics?.recordHistogram('search_total_ms', Date.now() - start);
+     }
+   }
+ 
+
+diff --git a/src/index.ts b/src/index.ts
+index ca15f7e..d4bf378 100644
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -42,16 +42,16 @@ async function main() {
+   const sqlite = new SqliteStore(config.data_dir!);
+   await sqlite.init();
+ 
++  const metrics = new MetricsCollector(config);
+   const qdrant = new QdrantStore(config);
+-  const embedding = createEmbeddingProvider(config);
++  const embedding = createEmbeddingProvider(config, { metrics });
+   const storage = new StorageManager(sqlite, qdrant, embedding);
+ 
+   // Initialize services
+   const pipeline = new WritePipeline(config, storage, embedding);
+-  const searchService = new SearchService(config, storage, embedding);
++  const searchService = new SearchService(config, storage, embedding, metrics);
+   const backupService = new BackupService(config, storage, logger);
+   const healthService = new HealthService(storage, embedding, config);
+-  const metrics = new MetricsCollector(config);
+ 
+   const ctx: ToolContext = {
+     config, storage, embedding, pipeline,
+

--- a/temp_stage/search.head.ts
+++ b/temp_stage/search.head.ts
@@ -1,0 +1,264 @@
+import type { BrainConfig } from '../config/index.js';
+import type { StorageManager } from '../storage/index.js';
+import type { EmbeddingProvider } from '../embedding/index.js';
+import type { SearchMode, SearchResult } from '../domain/types.js';
+import { MemoryLifecycleService } from '../domain/lifecycle.js';
+import { embeddingUnavailable, internal } from '../errors/index.js';
+
+const RRF_K = 60;
+
+interface RankedItem {
+  id: string;
+  semanticRank?: number;
+  fulltextRank?: number;
+  semanticScore?: number;
+  fulltextScore?: number;
+}
+
+export class SearchService {
+  private lifecycle: MemoryLifecycleService;
+
+  constructor(
+    private config: BrainConfig,
+    private storage: StorageManager,
+    private embedding: EmbeddingProvider,
+  ) {
+    this.lifecycle = new MemoryLifecycleService(config);
+  }
+
+  async search(
+    query: string,
+    namespace: string,
+    collection: string | undefined,
+    mode: SearchMode,
+    limit: number,
+  ): Promise<SearchResult[]> {
+    switch (mode) {
+      case 'semantic':
+        return this.semanticSearch(query, namespace, collection, limit);
+      case 'fulltext':
+        return this.fulltextSearch(query, namespace, collection, limit);
+      case 'hybrid':
+        return this.hybridSearch(query, namespace, collection, limit);
+    }
+  }
+
+  private async semanticSearch(
+    query: string,
+    namespace: string,
+    collection: string | undefined,
+    limit: number,
+  ): Promise<SearchResult[]> {
+    let vector: number[];
+    try {
+      vector = await this.embedding.embed(query);
+    } catch {
+      throw embeddingUnavailable('Cannot perform semantic search: embedding provider unavailable');
+    }
+
+    let results: Array<{ id: string; score: number; payload: Record<string, unknown> }>;
+    try {
+      results = await this.storage.qdrant.search(
+        namespace, collection, vector, limit,
+      );
+    } catch (err) {
+      throw internal(`Semantic search failed: vector store unavailable — ${(err as Error).message}`);
+    }
+
+    return this.buildSearchResults(
+      results.map(r => ({
+        id: r.id,
+        score: r.score,
+        semantic_score: r.score,
+      })),
+    );
+  }
+
+  private fulltextSearch(
+    query: string,
+    namespace: string,
+    collection: string | undefined,
+    limit: number,
+  ): SearchResult[] {
+    const ftsResults = this.storage.sqlite.fullTextSearch(namespace, query, limit, collection);
+    return this.buildSearchResults(
+      ftsResults.map(r => {
+        const normalizedScore = Math.min(1, Math.abs(r.rank) / 10);
+        return {
+          id: r.id,
+          score: normalizedScore,
+          fulltext_score: normalizedScore,
+        };
+      }),
+    );
+  }
+
+  private async hybridSearch(
+    query: string,
+    namespace: string,
+    collection: string | undefined,
+    limit: number,
+  ): Promise<SearchResult[]> {
+    const weights = this.config.search.hybrid_weights;
+
+    // Run both searches in parallel where possible
+    let semanticItems: Array<{ id: string; score: number }> = [];
+    const fulltextItems = this.storage.sqlite.fullTextSearch(namespace, query, limit * 2, collection);
+
+    try {
+      const vector = await this.embedding.embed(query);
+      const qdrantResults = await this.storage.qdrant.search(
+        namespace, collection, vector, limit * 2,
+      );
+      semanticItems = qdrantResults.map(r => ({ id: r.id, score: r.score }));
+    } catch {
+      // Embedding unavailable: fall back to fulltext only
+    }
+
+    // Build RRF fusion
+    const itemMap = new Map<string, RankedItem>();
+
+    semanticItems.forEach((item, idx) => {
+      const existing = itemMap.get(item.id) ?? { id: item.id };
+      existing.semanticRank = idx + 1;
+      existing.semanticScore = item.score;
+      itemMap.set(item.id, existing);
+    });
+
+    fulltextItems.forEach((item, idx) => {
+      const existing = itemMap.get(item.id) ?? { id: item.id };
+      existing.fulltextRank = idx + 1;
+      existing.fulltextScore = Math.min(1, Math.abs(item.rank) / 10);
+      itemMap.set(item.id, existing);
+    });
+
+    // Compute RRF scores
+    const scored = Array.from(itemMap.values()).map(item => {
+      const semanticRrf = item.semanticRank
+        ? weights.semantic / (RRF_K + item.semanticRank)
+        : 0;
+      const fulltextRrf = item.fulltextRank
+        ? weights.fulltext / (RRF_K + item.fulltextRank)
+        : 0;
+      return {
+        ...item,
+        rrfScore: semanticRrf + fulltextRrf,
+      };
+    });
+
+    scored.sort((a, b) => b.rrfScore - a.rrfScore);
+
+    return this.buildSearchResults(
+      scored.slice(0, limit).map(item => ({
+        id: item.id,
+        score: item.rrfScore,
+        semantic_score: item.semanticScore,
+        fulltext_score: item.fulltextScore,
+      })),
+      { boostT0: true },
+    );
+  }
+
+  private buildSearchResults(
+    ranked: Array<{ id: string; score: number; semantic_score?: number; fulltext_score?: number }>,
+    options?: { boostT0?: boolean },
+  ): SearchResult[] {
+    const now = new Date();
+    const nowIso = now.toISOString();
+    const memories = typeof (this.storage.sqlite as any).getMemoriesByIds === 'function'
+      ? this.storage.sqlite.getMemoriesByIds(ranked.map(item => item.id))
+      : ranked
+        .map(item => this.storage.sqlite.getMemoryById(item.id))
+        .filter(Boolean);
+    const memoryMap = new Map(memories.map((mem: any) => [mem.id, mem]));
+    const accessUpdates: Array<{
+      id: string;
+      access_count: number;
+      last_accessed: string;
+      expires_at?: string | null;
+      retention_tier?: SearchResult['retention_tier'];
+      review_due?: string | null;
+    }> = [];
+    const searchResults: SearchResult[] = [];
+
+    for (const item of ranked) {
+      const mem = memoryMap.get(item.id);
+      if (!mem) continue;
+      if (this.lifecycle.isExpired(mem.expires_at, now)) continue;
+
+      let adjustedScore = item.score;
+      if (options?.boostT0 && mem.retention_tier === 'T0') {
+        adjustedScore += 0.1;
+      }
+
+      accessUpdates.push(this.buildAccessUpdate(mem, now, nowIso));
+      searchResults.push({
+        id: mem.id,
+        content: mem.content,
+        summary: mem.summary,
+        type: mem.type,
+        tags: mem.tags,
+        score: adjustedScore,
+        semantic_score: item.semantic_score,
+        fulltext_score: item.fulltext_score,
+        retention_tier: mem.retention_tier,
+        expires_at: mem.expires_at,
+        expiring_soon: this.lifecycle.isExpiringSoon(mem.expires_at, now),
+        created_at: mem.created_at,
+        last_accessed: nowIso,
+      });
+    }
+
+    if (accessUpdates.length > 0) {
+      if (typeof (this.storage.sqlite as any).recordAccessBatch === 'function') {
+        this.storage.sqlite.recordAccessBatch(accessUpdates);
+      } else if (typeof (this.storage.sqlite as any).recordAccess === 'function') {
+        for (const update of accessUpdates) {
+          this.storage.sqlite.recordAccess(
+            update.id,
+            update.access_count,
+            update.last_accessed,
+            update.expires_at,
+            update.retention_tier,
+            update.review_due,
+          );
+        }
+      } else {
+        for (const update of accessUpdates) {
+          this.storage.sqlite.touchMemory(update.id);
+        }
+      }
+      this.storage.sqlite.scheduleDeferredFlush();
+    }
+
+    return searchResults;
+  }
+
+  private buildAccessUpdate(
+    mem: { id: string; access_count: number; retention_tier: SearchResult['retention_tier']; expires_at: string | null },
+    now: Date,
+    nowIso: string,
+  ): {
+    id: string;
+    access_count: number;
+    last_accessed: string;
+    expires_at?: string | null;
+    retention_tier?: SearchResult['retention_tier'];
+    review_due?: string | null;
+  } {
+    const nextAccessCount = mem.access_count + 1;
+    const promotedTier = this.lifecycle.shouldPromote(mem.retention_tier, nextAccessCount) ?? mem.retention_tier;
+    const nextExpiry = this.lifecycle.extendExpiry(promotedTier, now);
+    const nextReviewDue = promotedTier === 'T1'
+      ? this.lifecycle.computeExpiry('T1', now)
+      : undefined;
+    return {
+      id: mem.id,
+      access_count: nextAccessCount,
+      last_accessed: nowIso,
+      expires_at: nextExpiry === null ? null : nextExpiry,
+      retention_tier: promotedTier !== mem.retention_tier ? promotedTier : undefined,
+      review_due: nextReviewDue,
+    };
+  }
+}

--- a/temp_stage/search.index.ts
+++ b/temp_stage/search.index.ts
@@ -1,0 +1,273 @@
+import type { BrainConfig } from '../config/index.js';
+import type { StorageManager } from '../storage/index.js';
+import type { EmbeddingProvider } from '../embedding/index.js';
+import type { SearchMode, SearchResult } from '../domain/types.js';
+import type { MetricsCollector } from '../health/metrics.js';
+import { MemoryLifecycleService } from '../domain/lifecycle.js';
+import { embeddingUnavailable, internal } from '../errors/index.js';
+
+const RRF_K = 60;
+
+interface RankedItem {
+  id: string;
+  semanticRank?: number;
+  fulltextRank?: number;
+  semanticScore?: number;
+  fulltextScore?: number;
+}
+
+export class SearchService {
+  private lifecycle: MemoryLifecycleService;
+
+  constructor(
+    private config: BrainConfig,
+    private storage: StorageManager,
+    private embedding: EmbeddingProvider,
+    private metrics?: MetricsCollector,
+  ) {
+    this.lifecycle = new MemoryLifecycleService(config);
+  }
+
+  async search(
+    query: string,
+    namespace: string,
+    collection: string | undefined,
+    mode: SearchMode,
+    limit: number,
+  ): Promise<SearchResult[]> {
+    const start = Date.now();
+    try {
+      switch (mode) {
+        case 'semantic':
+          return await this.semanticSearch(query, namespace, collection, limit);
+        case 'fulltext':
+          return this.fulltextSearch(query, namespace, collection, limit);
+        case 'hybrid':
+          return await this.hybridSearch(query, namespace, collection, limit);
+      }
+      const unsupportedMode: never = mode;
+      throw new Error(`Unsupported search mode: ${unsupportedMode}`);
+    } finally {
+      this.metrics?.recordHistogram('search_total_ms', Date.now() - start);
+    }
+  }
+
+  private async semanticSearch(
+    query: string,
+    namespace: string,
+    collection: string | undefined,
+    limit: number,
+  ): Promise<SearchResult[]> {
+    let vector: number[];
+    try {
+      vector = await this.embedding.embed(query);
+    } catch {
+      throw embeddingUnavailable('Cannot perform semantic search: embedding provider unavailable');
+    }
+
+    let results: Array<{ id: string; score: number; payload: Record<string, unknown> }>;
+    try {
+      results = await this.storage.qdrant.search(
+        namespace, collection, vector, limit,
+      );
+    } catch (err) {
+      throw internal(`Semantic search failed: vector store unavailable — ${(err as Error).message}`);
+    }
+
+    return this.buildSearchResults(
+      results.map(r => ({
+        id: r.id,
+        score: r.score,
+        semantic_score: r.score,
+      })),
+    );
+  }
+
+  private fulltextSearch(
+    query: string,
+    namespace: string,
+    collection: string | undefined,
+    limit: number,
+  ): SearchResult[] {
+    const ftsResults = this.storage.sqlite.fullTextSearch(namespace, query, limit, collection);
+    return this.buildSearchResults(
+      ftsResults.map(r => {
+        const normalizedScore = Math.min(1, Math.abs(r.rank) / 10);
+        return {
+          id: r.id,
+          score: normalizedScore,
+          fulltext_score: normalizedScore,
+        };
+      }),
+    );
+  }
+
+  private async hybridSearch(
+    query: string,
+    namespace: string,
+    collection: string | undefined,
+    limit: number,
+  ): Promise<SearchResult[]> {
+    const weights = this.config.search.hybrid_weights;
+
+    // Run both searches in parallel where possible
+    let semanticItems: Array<{ id: string; score: number }> = [];
+    const fulltextItems = this.storage.sqlite.fullTextSearch(namespace, query, limit * 2, collection);
+
+    try {
+      const vector = await this.embedding.embed(query);
+      const qdrantResults = await this.storage.qdrant.search(
+        namespace, collection, vector, limit * 2,
+      );
+      semanticItems = qdrantResults.map(r => ({ id: r.id, score: r.score }));
+    } catch {
+      // Embedding unavailable: fall back to fulltext only
+    }
+
+    // Build RRF fusion
+    const itemMap = new Map<string, RankedItem>();
+
+    semanticItems.forEach((item, idx) => {
+      const existing = itemMap.get(item.id) ?? { id: item.id };
+      existing.semanticRank = idx + 1;
+      existing.semanticScore = item.score;
+      itemMap.set(item.id, existing);
+    });
+
+    fulltextItems.forEach((item, idx) => {
+      const existing = itemMap.get(item.id) ?? { id: item.id };
+      existing.fulltextRank = idx + 1;
+      existing.fulltextScore = Math.min(1, Math.abs(item.rank) / 10);
+      itemMap.set(item.id, existing);
+    });
+
+    // Compute RRF scores
+    const scored = Array.from(itemMap.values()).map(item => {
+      const semanticRrf = item.semanticRank
+        ? weights.semantic / (RRF_K + item.semanticRank)
+        : 0;
+      const fulltextRrf = item.fulltextRank
+        ? weights.fulltext / (RRF_K + item.fulltextRank)
+        : 0;
+      return {
+        ...item,
+        rrfScore: semanticRrf + fulltextRrf,
+      };
+    });
+
+    scored.sort((a, b) => b.rrfScore - a.rrfScore);
+
+    return this.buildSearchResults(
+      scored.slice(0, limit).map(item => ({
+        id: item.id,
+        score: item.rrfScore,
+        semantic_score: item.semanticScore,
+        fulltext_score: item.fulltextScore,
+      })),
+      { boostT0: true },
+    );
+  }
+
+  private buildSearchResults(
+    ranked: Array<{ id: string; score: number; semantic_score?: number; fulltext_score?: number }>,
+    options?: { boostT0?: boolean },
+  ): SearchResult[] {
+    const now = new Date();
+    const nowIso = now.toISOString();
+    const memories = typeof (this.storage.sqlite as any).getMemoriesByIds === 'function'
+      ? this.storage.sqlite.getMemoriesByIds(ranked.map(item => item.id))
+      : ranked
+        .map(item => this.storage.sqlite.getMemoryById(item.id))
+        .filter(Boolean);
+    const memoryMap = new Map(memories.map((mem: any) => [mem.id, mem]));
+    const accessUpdates: Array<{
+      id: string;
+      access_count: number;
+      last_accessed: string;
+      expires_at?: string | null;
+      retention_tier?: SearchResult['retention_tier'];
+      review_due?: string | null;
+    }> = [];
+    const searchResults: SearchResult[] = [];
+
+    for (const item of ranked) {
+      const mem = memoryMap.get(item.id);
+      if (!mem) continue;
+      if (this.lifecycle.isExpired(mem.expires_at, now)) continue;
+
+      let adjustedScore = item.score;
+      if (options?.boostT0 && mem.retention_tier === 'T0') {
+        adjustedScore += 0.1;
+      }
+
+      accessUpdates.push(this.buildAccessUpdate(mem, now, nowIso));
+      searchResults.push({
+        id: mem.id,
+        content: mem.content,
+        summary: mem.summary,
+        type: mem.type,
+        tags: mem.tags,
+        score: adjustedScore,
+        semantic_score: item.semantic_score,
+        fulltext_score: item.fulltext_score,
+        retention_tier: mem.retention_tier,
+        expires_at: mem.expires_at,
+        expiring_soon: this.lifecycle.isExpiringSoon(mem.expires_at, now),
+        created_at: mem.created_at,
+        last_accessed: nowIso,
+      });
+    }
+
+    if (accessUpdates.length > 0) {
+      if (typeof (this.storage.sqlite as any).recordAccessBatch === 'function') {
+        this.storage.sqlite.recordAccessBatch(accessUpdates);
+      } else if (typeof (this.storage.sqlite as any).recordAccess === 'function') {
+        for (const update of accessUpdates) {
+          this.storage.sqlite.recordAccess(
+            update.id,
+            update.access_count,
+            update.last_accessed,
+            update.expires_at,
+            update.retention_tier,
+            update.review_due,
+          );
+        }
+      } else {
+        for (const update of accessUpdates) {
+          this.storage.sqlite.touchMemory(update.id);
+        }
+      }
+      this.storage.sqlite.scheduleDeferredFlush();
+    }
+
+    return searchResults;
+  }
+
+  private buildAccessUpdate(
+    mem: { id: string; access_count: number; retention_tier: SearchResult['retention_tier']; expires_at: string | null },
+    now: Date,
+    nowIso: string,
+  ): {
+    id: string;
+    access_count: number;
+    last_accessed: string;
+    expires_at?: string | null;
+    retention_tier?: SearchResult['retention_tier'];
+    review_due?: string | null;
+  } {
+    const nextAccessCount = mem.access_count + 1;
+    const promotedTier = this.lifecycle.shouldPromote(mem.retention_tier, nextAccessCount) ?? mem.retention_tier;
+    const nextExpiry = this.lifecycle.extendExpiry(promotedTier, now);
+    const nextReviewDue = promotedTier === 'T1'
+      ? this.lifecycle.computeExpiry('T1', now)
+      : undefined;
+    return {
+      id: mem.id,
+      access_count: nextAccessCount,
+      last_accessed: nowIso,
+      expires_at: nextExpiry === null ? null : nextExpiry,
+      retention_tier: promotedTier !== mem.retention_tier ? promotedTier : undefined,
+      review_due: nextReviewDue,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

This branch combines two areas of work:

### 1. Fix: stdio logger stdout pollution
- Redirect pino logs to stderr in stdio transport mode to prevent JSON-RPC stdout pollution
- Docs updated to reflect stderr routing

### 2. Code Review 2 improvements
- Add OpenSpec skills, prompts, and change specs
- Type safety refactor: eliminate `as-any` casting with typed interfaces and `SqlParams`
- Circuit breakers for OpenAI and Qdrant with health visibility
- p50/p95/p99 percentile metrics to `MetricsCollector`
- Test coverage for embedding, HTTP transport, metrics, logger, health, and CLI

### 3. Harden post-restore reconciliation
- Refactor `BackupService.restore` with fail-safe guard acquisition via `beginRestoreOperation()`
- Post-SQLite-activation vector failures now return degraded readiness instead of full restore failure
- Extract `restoreVectorStateAfterActivation()` with per-step error isolation
- Reconciliation progress flushed incrementally (`flushIfDirty` on each upsert)
- Extract `toPendingVectorReconciliation()` helper to deduplicate degraded-state reporting
- Add regression tests: vector-clear failure, partial reconciliation durability, restore guard cleanup
- All openspec tasks marked complete

## Testing
- `npm run lint` ✅
- `npm test` ✅
- `npm run build` ✅