### PR TITLE
docs: sync embedding/config docs with Azure Foundry provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,46 @@
 # BHGBrain Docker Environment Variables
 # Copy this file to .env and fill in your values.
+#
+# NOTE: This file holds SECRETS and a few runtime overrides only.
+# Embedding provider selection, model, dimensions, and the Azure resource
+# name are configured in config.json (see README "Configuration"), not here.
+# The variables below are the API keys those settings reference, plus the
+# BHGBRAIN_* overrides applied on top of config.json (handy in containers).
 
-# Required: OpenAI API key for embeddings
+# --- Embeddings ---
+# Required when embedding.provider = "openai" (the default).
+# This is the env var named by embedding.api_key_env in config.json.
 OPENAI_API_KEY=sk-...
 
+# Required when embedding.provider = "azure-foundry".
+# Set embedding.provider + embedding.azure.resource_name in config.json,
+# then put the Azure Foundry API key here (named by embedding.azure.api_key_env,
+# which defaults to AZURE_FOUNDRY_API_KEY). The endpoint is derived from
+# resource_name: https://<resource_name>.openai.azure.com
+# AZURE_FOUNDRY_API_KEY=
+
+# Optional: API key for the extraction-pipeline LLM (pipeline.extraction_model).
+# Named by pipeline.extraction_model_env in config.json (default below).
+# BHGBRAIN_EXTRACTION_API_KEY=
+
+# --- HTTP transport / security ---
 # Required for authenticated HTTP access
 BHGBRAIN_TOKEN=
 
+# Optional: HTTP bind host/port overrides (defaults: 127.0.0.1:3721)
+# BHGBRAIN_HTTP_HOST=0.0.0.0
+# BHGBRAIN_HTTP_PORT=3721
+
+# Optional: relax HTTP security (use with care)
+# BHGBRAIN_REQUIRE_LOOPBACK=false
+# BHGBRAIN_ALLOW_UNAUTHENTICATED=false
+
+# --- Runtime ---
 # Optional: Override device identity (defaults to container hostname)
 # BHGBRAIN_DEVICE_ID=my-docker-host
+
+# Optional: Override data directory
+# BHGBRAIN_DATA_DIR=/data
 
 # Optional: Log level (debug, info, warn, error)
 # BHGBRAIN_LOG_LEVEL=info
@@ -20,4 +52,5 @@ BHGBRAIN_TOKEN=
 # --- Qdrant Cloud (docker compose up) ---
 # BHGBRAIN_QDRANT_MODE=external
 # BHGBRAIN_QDRANT_URL=https://your-cluster.cloud.qdrant.io:6333
+# Set qdrant.api_key_env = "QDRANT_API_KEY" in config.json, then provide it here.
 # QDRANT_API_KEY=your-qdrant-cloud-api-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ BHGBrain is a persistent, vector-backed memory system for MCP (Model Context Pro
 - ES modules (`"type": "module"`)
 - SQLite for metadata storage (via sql.js)
 - Qdrant for vector storage
-- OpenAI for embeddings
+- OpenAI or Azure Foundry for embeddings (selectable via `embedding.provider`)
 - Express.js for HTTP transport
 - MCP SDK for stdio transport
 - Vitest for testing
@@ -38,7 +38,7 @@ src/
 ├── types.d.ts            # TypeScript declarations for sql.js
 ├── config/               # Configuration management with Zod schemas
 ├── storage/              # SQLite + Qdrant data layer
-├── embedding/            # OpenAI embedding provider
+├── embedding/            # Embedding providers (OpenAI + Azure Foundry)
 ├── pipeline/             # Write pipeline (extraction → decision → store)
 ├── bootstrap/            # Onboarding: section definitions, session state
 ├── search/               # Hybrid semantic + fulltext search
@@ -114,12 +114,41 @@ describe('feature', () => {
 
 ## Configuration System
 
-- **Schema**: Zod validation with defaults
+- **Schema**: Zod validation with defaults (`src/config/index.ts`)
 - **Format**: JSON at `{data_dir}/config.json`
-- **Environment**: Supports env var references (e.g., `OPENAI_API_KEY`)
 - **Location**: Platform-specific data directories
   - Windows: `%LOCALAPPDATA%\BHGBrain`
   - Unix: `~/.bhgbrain`
+
+### Config vs. environment
+
+Most settings (including **embedding provider/model/dimensions**) live **only** in
+`config.json`. The environment supplies just two things:
+
+1. **Secrets**, referenced indirectly by `*_api_key_env` keys. The config stores the
+   *name* of the env var to read, not the secret itself:
+   - `embedding.api_key_env` → defaults to `OPENAI_API_KEY`
+   - `embedding.azure.api_key_env` → defaults to `AZURE_FOUNDRY_API_KEY`
+   - `qdrant.api_key_env` → null by default; set to `"QDRANT_API_KEY"` for Qdrant Cloud
+   - `pipeline.extraction_model_env` → defaults to `BHGBRAIN_EXTRACTION_API_KEY`
+2. **Runtime overrides** applied by `applyEnvOverrides()` — a fixed set only:
+   `BHGBRAIN_DATA_DIR`, `BHGBRAIN_HTTP_HOST`, `BHGBRAIN_HTTP_PORT`,
+   `BHGBRAIN_QDRANT_MODE`, `BHGBRAIN_QDRANT_URL`, `BHGBRAIN_REQUIRE_LOOPBACK`,
+   `BHGBRAIN_ALLOW_UNAUTHENTICATED`, `BHGBRAIN_LOG_LEVEL`, plus `BHGBRAIN_DEVICE_ID`.
+
+Setting an env var outside these two categories has **no effect**. See `.env.example`
+for the full, documented variable list.
+
+### Embedding providers
+
+Selected via `embedding.provider` in `config.json`:
+
+- **`openai`** (default) — `src/embedding/index.ts`; key from `OPENAI_API_KEY`.
+- **`azure-foundry`** — `src/embedding/azure-foundry.ts`; requires
+  `embedding.azure.resource_name`. Endpoint is derived as
+  `https://<resource_name>.openai.azure.com`; key from `AZURE_FOUNDRY_API_KEY`.
+  Note the per-model dimension constraints enforced by the Zod schema
+  (e.g. `text-embedding-3-small` ≤ 1536, `text-embedding-3-large` ≤ 3072).
 
 ## Error Handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# CLAUDE.md
+
+Guidance for Claude Code (and other agents) working in this repository.
+
+The full development guide lives in **[AGENTS.md](./AGENTS.md)** — read it first. It
+covers commands, codebase structure, design patterns, configuration (including the two
+embedding providers and how config/env resolve), testing, and common gotchas.
+
+@AGENTS.md
+
+---
+
+## MCP tools (canonical list)
+
+Tool schemas live in `src/tools/schemas.ts` (plus `bootstrap.ts` / `import.ts`). The
+registered tools are: `remember`, `recall`, `forget`, `search`, `tag`, `collections`,
+`category`, `backup`, `bootstrap`, `import`, `repair`. Keep `src/tools/schemas.ts`,
+`README.md` (§ "MCP Tools Reference"), and any new handler in sync when changing tools.
+
+## Docs to keep in sync when behavior changes
+
+- `README.md` — user-facing reference (tools, env vars, config).
+- `.env.example` — environment variables.
+- `AGENTS.md` — developer guide.
+- `package.json` `version` — bump on user-visible changes.
+- `openspec/changes/` — check for an existing proposal before implementing a feature.


### PR DESCRIPTION
## Summary

Brings the project docs in line with the code after the Azure Foundry embedding provider was added (v1.4). Previously the docs described OpenAI as the only embedding provider and `.env.example` omitted several supported variables.

## Changes

- **`.env.example`** — document `AZURE_FOUNDRY_API_KEY`, `BHGBRAIN_EXTRACTION_API_KEY`, and the HTTP/security overrides; clarify that embedding provider/model/dimensions are `config.json`-only and the environment supplies just secrets (via `*_api_key_env`) plus the fixed `BHGBRAIN_*` override set.
- **`AGENTS.md`** — note both OpenAI + Azure Foundry embedding providers; expand the Configuration section with config-vs-env resolution and provider details (endpoint derivation, per-model dimension caps).
- **`CLAUDE.md`** *(new)* — entry point that imports `AGENTS.md`, plus the canonical MCP tool list and a docs-to-keep-in-sync checklist.

## Verification

All details checked against the code this covers — `src/config/index.ts` (Zod schema + `applyEnvOverrides`), `src/embedding/azure-foundry.ts`, and `src/tools/schemas.ts`. README was already in sync and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)